### PR TITLE
feat: implement #17 — LOW: No webhook payload size limit

### DIFF
--- a/internal/app/webhook.go
+++ b/internal/app/webhook.go
@@ -4,10 +4,13 @@ import (
 	"crypto/hmac"
 	"crypto/sha256"
 	"encoding/hex"
+	"errors"
 	"io"
 	"net/http"
 	"strings"
 )
+
+const maxWebhookPayloadBytes = 25 * 1024 * 1024 // 25 MB — GitHub's documented limit
 
 type EventCallback func(eventType string, payload []byte)
 
@@ -21,9 +24,15 @@ func NewWebhookHandler(secret string, callback EventCallback) *WebhookHandler {
 }
 
 func (h *WebhookHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	r.Body = http.MaxBytesReader(w, r.Body, maxWebhookPayloadBytes)
 	body, err := io.ReadAll(r.Body)
 	if err != nil {
-		http.Error(w, "read error", http.StatusBadRequest)
+		var maxErr *http.MaxBytesError
+		if errors.As(err, &maxErr) {
+			http.Error(w, "payload too large", http.StatusRequestEntityTooLarge)
+		} else {
+			http.Error(w, "read error", http.StatusBadRequest)
+		}
 		return
 	}
 

--- a/internal/app/webhook_test.go
+++ b/internal/app/webhook_test.go
@@ -32,6 +32,23 @@ func TestWebhookSignatureValidation(t *testing.T) {
 	assert.Equal(t, http.StatusOK, rr.Code)
 }
 
+func TestWebhookRejectsOversizedPayload(t *testing.T) {
+	handler := NewWebhookHandler("secret", func(eventType string, payload []byte) {
+		t.Fatal("callback should not be invoked for oversized payload")
+	})
+
+	// Create a payload that exceeds the 25MB limit
+	oversized := strings.Repeat("x", 25*1024*1024+1)
+	req := httptest.NewRequest("POST", "/webhooks/github", strings.NewReader(oversized))
+	req.Header.Set("X-Hub-Signature-256", "sha256=irrelevant")
+	req.Header.Set("X-GitHub-Event", "issues")
+
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusRequestEntityTooLarge, rr.Code)
+}
+
 func TestWebhookRejectsInvalidSignature(t *testing.T) {
 	handler := NewWebhookHandler("secret", func(eventType string, payload []byte) {})
 


### PR DESCRIPTION
## Implementation for #17

**Issue:** LOW: No webhook payload size limit

### Approved Plan
### Approach

Add `http.MaxBytesReader` in `WebhookHandler.ServeHTTP` to wrap `r.Body` before calling `io.ReadAll`. This enforces a size limit at the HTTP layer, preventing memory exhaustion from oversized payloads. GitHub documents a 25MB webhook payload limit, so we cap at 25MB. No changes needed in `events.go` — it already receives `[]byte` slices that will have been size-checked upstream.

### Files to Modify

1. **`internal/app/webhook.go`** — Add `http.MaxBytesReader` before body read; detect `MaxBytesError` for a proper 413 response.
2. **`internal/app/webhook_test.go`** — Add test for oversized payloads.

### Implementation Steps

**Step 1: Add a payload size constant and apply `MaxBytesReader` (`internal/app/webhook.go`)**

Add a constant for the max payload size:

```go
const maxWebhookPayloadBytes = 25 * 1024 * 1024 // 25 MB — GitHub's documented limit
```

In `ServeHTTP`, wrap `r.Body` with `http.MaxBytesReader` before `io.ReadAll`:

```go
func (h *WebhookHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
	r.Body = http.MaxBytesReader(w, r.Body, maxWebhookPayloadBytes)
	body, err := io.ReadAll(r.Body)
	if err != nil {
		http.Error(w, "payload too large", http.StatusRequestEntityTooLarge)
		return
	}
	// ... rest unchanged
}
```

Note: `http.MaxBytesReader` returns a `*http.MaxBytesError` when the limit is exceeded. `io.ReadAll` propagates this error, so the existing `err != nil` check catches it. The only behavioral change is the error message and status code — previously any read error returned 400; now all read errors (including oversized) return 413. This is acceptable because a legitimate read error on a webhook is exceedingly rare and a 413 is still a 4xx client error.

If we want to preserve the 400 for non-size read errors, we can type-check:

```go
if err != nil {
	var maxErr *http.MaxBytesError
	if errors.As(err, &maxErr) {
		http.Error(w, "payload too large", http.StatusRequestEntityTooLarge)
	} else {
		http.Error(w, "read error", ht

### Files Changed
- `internal/app/webhook.go`
- `internal/app/webhook_test.go`

---
*Created by NeuralWarden Autopilot Issues Agent*