### PR TITLE
feat: implement #12 — MEDIUM: Verify stage can panic on empty command

### DIFF
--- a/internal/pipeline/verify.go
+++ b/internal/pipeline/verify.go
@@ -12,6 +12,7 @@ type VerifyStage struct {
 }
 
 func NewVerifyStage(command string) *VerifyStage {
+	command = strings.TrimSpace(command)
 	if command == "" {
 		command = "make test"
 	}
@@ -29,6 +30,12 @@ func (s *VerifyStage) Run(_ context.Context, state *PipelineState) (StageResult,
 	}
 
 	parts := strings.Fields(s.command)
+	if len(parts) == 0 {
+		return StageResult{
+			Status: StatusSkipped,
+			Output: "no verify command configured",
+		}, nil
+	}
 	cmd := exec.Command(parts[0], parts[1:]...)
 	cmd.Dir = state.Repo.LocalPath
 

--- a/internal/pipeline/verify_test.go
+++ b/internal/pipeline/verify_test.go
@@ -1,0 +1,73 @@
+package pipeline
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestVerifyStageEmptyCommand(t *testing.T) {
+	tests := []struct {
+		name    string
+		command string
+		want    string
+	}{
+		{"empty string defaults to make test", "", "make test"},
+		{"whitespace only defaults to make test", "   ", "make test"},
+		{"tab and spaces defaults to make test", " \t ", "make test"},
+		{"valid command preserved", "go test ./...", "go test ./..."},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			stage := NewVerifyStage(tt.command)
+			assert.Equal(t, tt.want, stage.command)
+		})
+	}
+}
+
+func TestVerifyStageRunEmptyParts(t *testing.T) {
+	// Directly construct VerifyStage with empty command (bypassing constructor)
+	// to verify Run() doesn't panic
+	s := &VerifyStage{command: ""}
+	state := &PipelineState{Repo: RepoContext{LocalPath: "/tmp"}}
+	result, err := s.Run(context.Background(), state)
+	assert.NoError(t, err)
+	assert.Equal(t, StatusSkipped, result.Status)
+	assert.Equal(t, "no verify command configured", result.Output)
+}
+
+func TestVerifyStageRunWhitespaceOnlyParts(t *testing.T) {
+	// Directly construct with whitespace-only command (bypassing constructor)
+	s := &VerifyStage{command: "   "}
+	state := &PipelineState{Repo: RepoContext{LocalPath: "/tmp"}}
+	result, err := s.Run(context.Background(), state)
+	assert.NoError(t, err)
+	assert.Equal(t, StatusSkipped, result.Status)
+	assert.Equal(t, "no verify command configured", result.Output)
+}
+
+func TestVerifyStageRunNoLocalPath(t *testing.T) {
+	s := NewVerifyStage("echo hello")
+	state := &PipelineState{}
+	result, err := s.Run(context.Background(), state)
+	assert.NoError(t, err)
+	assert.Equal(t, StatusSkipped, result.Status)
+	assert.Equal(t, "no local path available", result.Output)
+}
+
+func TestVerifyStageRunValidCommand(t *testing.T) {
+	s := NewVerifyStage("echo hello")
+	state := &PipelineState{Repo: RepoContext{LocalPath: "/tmp"}}
+	result, err := s.Run(context.Background(), state)
+	assert.NoError(t, err)
+	assert.Equal(t, StatusPassed, result.Status)
+	assert.NotNil(t, state.TestResults)
+	assert.True(t, state.TestResults.Passed)
+}
+
+func TestVerifyStageName(t *testing.T) {
+	s := NewVerifyStage("")
+	assert.Equal(t, "verify", s.Name())
+}


### PR DESCRIPTION
## Implementation for #12

**Issue:** MEDIUM: Verify stage can panic on empty command

### Approved Plan
I have all the information needed. Here is the implementation plan:

---

### Approach

The bug is on `verify.go:31-32`: `strings.Fields(s.command)` returns an empty slice when `s.command` is empty or whitespace-only, and the subsequent `parts[0]` access panics with an index-out-of-range error. Although `NewVerifyStage` defaults empty strings to `"make test"`, the `command` field is exported-settable-equivalent (struct literal bypass) and even the constructor only checks `== ""`, not whitespace-only strings like `"   "`.

The fix is to add a guard after `strings.Fields()` that returns a skip result when `parts` is empty. Additionally, harden `NewVerifyStage` to trim and validate the command input.

### Files to Modify

1. **`internal/pipeline/verify.go`** — Add empty-command guard in `Run()` and harden `NewVerifyStage`.
2. **`internal/pipeline/verify_test.go`** (new file) — Add unit tests for the empty/whitespace command cases.

### Implementation Steps

1. **`internal/pipeline/verify.go` — Harden `NewVerifyStage`** (line 15-17):

   Replace the simple `command == ""` check with a `strings.TrimSpace` check so whitespace-only commands also fall back to the default:
   ```go
   func NewVerifyStage(command string) *VerifyStage {
       command = strings.TrimSpace(command)
       if command == "" {
           command = "make test"
       }
       return &VerifyStage{command: command}
   }
   ```

2. **`internal/pipeline/verify.go` — Guard in `Run()`** (after line 31):

   After `parts := strings.Fields(s.command)`, add a check for an empty slice before accessing `parts[0]`:
   ```go
   parts := strings.Fields(s.command)
   if len(parts) == 0 {
       return StageResult{
           Status: StatusSkipped,
           Output: "no verify command configured",
       }, nil
   }
   cmd := exec.Command(parts[0], parts[1:]...)
   ```
   This is a defense-in-depth guard — even though the constructor now trims, the `Run` method should not panic if the command is somehow empty.

3.

### Files Changed
- `internal/pipeline/verify.go`
- `internal/pipeline/verify_test.go`

---
*Created by NeuralWarden Autopilot Issues Agent*