### PR TITLE
feat: implement #14 — MEDIUM: Budget only checked before stages, not after

### DIFF
--- a/internal/pipeline/engine.go
+++ b/internal/pipeline/engine.go
@@ -67,6 +67,10 @@ func (e *Engine) Run(ctx context.Context, state *PipelineState) error {
 			e.callback(state, stage.Name(), result.Status)
 		}
 
+		if e.config.BudgetUSD > 0 && state.Cost > e.config.BudgetUSD {
+			return fmt.Errorf("budget exceeded: $%.2f > $%.2f limit", state.Cost, e.config.BudgetUSD)
+		}
+
 		if result.Status == StatusFailed {
 			return fmt.Errorf("stage %s failed: %s", stage.Name(), result.Output)
 		}

--- a/internal/pipeline/engine_test.go
+++ b/internal/pipeline/engine_test.go
@@ -76,6 +76,33 @@ func TestEngineSkipsStage(t *testing.T) {
 	assert.Equal(t, StatusPassed, state.Stages[1].Status)
 }
 
+type costMutatingStage struct {
+	name    string
+	addCost float64
+}
+
+func (m *costMutatingStage) Name() string { return m.name }
+func (m *costMutatingStage) Run(_ context.Context, state *PipelineState) (StageResult, error) {
+	state.Cost += m.addCost
+	return StageResult{Status: StatusPassed, Output: "ok"}, nil
+}
+
+func TestEngineBudgetExceededMidStage(t *testing.T) {
+	stages := []Stage{
+		&costMutatingStage{name: "expensive", addCost: 3.0},
+		&mockStage{name: "next", result: StageResult{Status: StatusPassed}},
+	}
+	e := NewEngine(stages, &EngineConfig{BudgetUSD: 2.0})
+
+	state := &PipelineState{JobID: "test-budget-mid"}
+	err := e.Run(context.Background(), state)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "budget exceeded")
+	// The expensive stage ran and was logged, but "next" never ran
+	assert.Len(t, state.Stages, 1)
+	assert.Equal(t, "expensive", state.Stages[0].Name)
+}
+
 func TestEngineBudgetExceeded(t *testing.T) {
 	stages := []Stage{
 		&mockStage{name: "s1", result: StageResult{Status: StatusPassed}},


### PR DESCRIPTION
## Implementation for #14

**Issue:** MEDIUM: Budget only checked before stages, not after

### Approved Plan
Now I have a complete picture. Here's the implementation plan:

---

### Approach

The bug is in `engine.go:33-76`: the budget check at line 39 only runs **before** each stage starts. If a stage (e.g., `architect`, `review`, `security`) increments `state.Cost` past the budget during its `Run()` call, the pipeline won't notice until the *next* iteration of the loop. If it's the last stage, the overage is never caught at all.

The fix is straightforward: add a second budget check **after** each stage completes (after `state.Cost` has been updated by the stage) so the pipeline stops immediately when the budget is exceeded.

### Files to Modify

1. **`internal/pipeline/engine.go`** — Add post-stage budget check.
2. **`internal/pipeline/engine_test.go`** — Add test for mid-stage budget overage.

### Implementation Steps

**Step 1: Add post-stage budget check in `engine.go`**

In the `Run` method, after the stage result is recorded and the callback fires (after line 68), but before the `StatusFailed` check (line 70), insert a budget check:

```go
// After line 68 (callback), before line 70 (StatusFailed check):
if e.config.BudgetUSD > 0 && state.Cost > e.config.BudgetUSD {
    return fmt.Errorf("budget exceeded: $%.2f > $%.2f limit", state.Cost, e.config.BudgetUSD)
}
```

This reuses the exact same guard and error message as the pre-stage check on line 39, maintaining consistency. Placing it after the callback ensures the stage completion is still reported before the pipeline aborts.

**Step 2: Add test `TestEngineBudgetExceededMidStage` in `engine_test.go`**

Create a new mock stage type that mutates `state.Cost` during `Run()`, simulating a stage that consumes budget:

```go
type costMutatingStage struct {
	name    string
	addCost float64
}

func (m *costMutatingStage) Name() string { return m.name }
func (m *costMutatingStage) Run(_ context.Context, state *PipelineState) (StageResult, error) {
	state.Cost += m.addCost
	return StageResult{Status: StatusPassed, Output: "

### Files Changed
- `internal/pipeline/engine.go`
- `internal/pipeline/engine_test.go`

---
*Created by NeuralWarden Autopilot Issues Agent*