### PR TITLE
feat: implement #16 — MEDIUM: Unchecked w.Write() errors and temp dir cleanup

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -51,7 +51,9 @@ func New(cfg config.Config) (*App, error) {
 	mux.Handle("/webhooks/github", NewWebhookHandler(cfg.GitHub.WebhookSecret, a.handleEvent))
 	mux.HandleFunc("/health", func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
-		w.Write([]byte(`{"status":"ok"}`))
+		if _, err := w.Write([]byte(`{"status":"ok"}`)); err != nil {
+			slog.Error("failed to write health response", "error", err)
+		}
 	})
 
 	a.server = &http.Server{
@@ -174,7 +176,11 @@ func (a *App) buildJobHandler() worker.JobHandler {
 		if err != nil {
 			return fmt.Errorf("create temp dir: %w", err)
 		}
-		defer os.RemoveAll(tmpDir)
+		defer func() {
+			if err := os.RemoveAll(tmpDir); err != nil {
+				slog.Warn("failed to remove temp dir", "path", tmpDir, "error", err)
+			}
+		}()
 
 		cloneDir := filepath.Join(tmpDir, "repo")
 		cloneURL := fmt.Sprintf("https://github.com/%s.git", job.RepoFullName)

--- a/internal/app/webhook.go
+++ b/internal/app/webhook.go
@@ -5,6 +5,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"io"
+	"log/slog"
 	"net/http"
 	"strings"
 )
@@ -37,7 +38,9 @@ func (h *WebhookHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	go h.callback(eventType, body)
 
 	w.WriteHeader(http.StatusOK)
-	w.Write([]byte(`{"ok":true}`))
+	if _, err := w.Write([]byte(`{"ok":true}`)); err != nil {
+		slog.Error("failed to write webhook response", "error", err)
+	}
 }
 
 func (h *WebhookHandler) verifySignature(payload []byte, signature string) bool {


### PR DESCRIPTION
## Implementation for #16

**Issue:** MEDIUM: Unchecked w.Write() errors and temp dir cleanup

### Approved Plan
I now have a complete picture. Here is the implementation plan.

---

### Approach

Fix two categories of ignored errors flagged by static analysis:

1. **`w.Write()` calls** in `webhook.go:40` and `app.go:54` — capture the error return and log it. These are HTTP response body writes where the only practical failure is a disconnected client; returning an error to the caller isn't useful, but logging ensures observability.

2. **`os.RemoveAll()` in `app.go:177`** — capture the error from the deferred cleanup and log a warning. Temp dir cleanup failure is non-fatal but should be visible for ops debugging (disk pressure, leaked mounts, etc.).

### Files to Modify

1. **`internal/app/webhook.go`** — handle `w.Write()` error on line 40.
2. **`internal/app/app.go`** — handle `w.Write()` error on line 54; handle `os.RemoveAll()` error on line 177. Add `"log/slog"` import if not already present.

### Implementation Steps

**Step 1 — `internal/app/webhook.go:40`**

Add `"log/slog"` to the import block. Change line 40 from:

```go
w.Write([]byte(`{"ok":true}`))
```

to:

```go
if _, err := w.Write([]byte(`{"ok":true}`)); err != nil {
    slog.Error("failed to write webhook response", "error", err)
}
```

**Step 2 — `internal/app/app.go:54` (health endpoint)**

Change line 54 from:

```go
w.Write([]byte(`{"status":"ok"}`))
```

to:

```go
if _, err := w.Write([]byte(`{"status":"ok"}`)); err != nil {
    slog.Error("failed to write health response", "error", err)
}
```

No new imports needed — `app.go` already imports `"log/slog"`.

**Step 3 — `internal/app/app.go:177` (temp dir cleanup)**

Change line 177 from:

```go
defer os.RemoveAll(tmpDir)
```

to:

```go
defer func() {
    if err := os.RemoveAll(tmpDir); err != nil {
        slog.Warn("failed to remove temp dir", "path", tmpDir, "error", err)
    }
}()
```

### Testing

1. **Existing tests pass**: Run `make test` — the webhook tests use `httptest.NewRecorder` which never errors on `Write`, so behavior is unchanged.
2. **

### Files Changed
- `internal/app/app.go`
- `internal/app/webhook.go`

---
*Created by NeuralWarden Autopilot Issues Agent*