### PR TITLE
feat: implement #18 — LOW: Missing RBAC docs and health check for K8s

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,9 +133,16 @@ export NEURALFORGE_EXECUTOR=kubernetes
 kubectl create namespace neuralforge
 kubectl apply -f deploy/k8s-secrets.yaml  # see deploy/k8s-secrets.yaml.example
 
+# Apply RBAC (ServiceAccount + Role + RoleBinding)
+kubectl apply -f deploy/rbac.yaml
+
 # Build the Claude executor image
 docker build -f deploy/claude-executor.Dockerfile -t ghcr.io/neuralforge/claude-executor:latest .
 ```
+
+The RBAC manifest grants the `neuralforge` ServiceAccount permission to create/manage Jobs, read Pod logs, and access Secrets in the configured namespace. See `deploy/rbac.yaml` for details. Each executor pod runs with `serviceAccountName: neuralforge`.
+
+When the executor is set to `kubernetes`, the `/health` endpoint verifies K8s cluster connectivity and reports `{"status":"ok","k8s":"connected"}` or `{"status":"degraded","k8s":"<error>"}`.
 
 Pod lifecycle:
 1. Init container clones the repo (token from `neuralforge-git-token` Secret)

--- a/deploy/rbac.yaml
+++ b/deploy/rbac.yaml
@@ -1,0 +1,35 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: neuralforge
+  namespace: neuralforge
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: neuralforge-executor
+  namespace: neuralforge
+rules:
+  - apiGroups: ["batch"]
+    resources: ["jobs"]
+    verbs: ["create", "get", "list", "delete"]
+  - apiGroups: [""]
+    resources: ["pods", "pods/log"]
+    verbs: ["get", "list"]
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: neuralforge-executor
+  namespace: neuralforge
+subjects:
+  - kind: ServiceAccount
+    name: neuralforge
+    namespace: neuralforge
+roleRef:
+  kind: Role
+  name: neuralforge-executor
+  apiGroup: rbac.authorization.k8s.io

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -2,6 +2,7 @@ package app
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"log/slog"
 	"net"
@@ -22,10 +23,11 @@ import (
 
 // App wires together the store, worker pool, and HTTP server.
 type App struct {
-	cfg    config.Config
-	store  store.Store
-	pool   *worker.Pool
-	server *http.Server
+	cfg      config.Config
+	store    store.Store
+	pool     *worker.Pool
+	server   *http.Server
+	executor executor.Executor
 }
 
 // New creates a new App, opens the SQLite store, and runs migrations.
@@ -44,14 +46,26 @@ func New(cfg config.Config) (*App, error) {
 		store: s,
 	}
 
+	a.initExecutor()
 	handler := a.buildJobHandler()
 	a.pool = worker.NewPool(cfg.Workers, s, handler)
 
 	mux := http.NewServeMux()
 	mux.Handle("/webhooks/github", NewWebhookHandler(cfg.GitHub.WebhookSecret, a.handleEvent))
 	mux.HandleFunc("/health", func(w http.ResponseWriter, r *http.Request) {
+		status := map[string]string{"status": "ok"}
+		if hc, ok := a.executor.(executor.HealthChecker); ok {
+			if err := hc.Ping(r.Context()); err != nil {
+				status["status"] = "degraded"
+				status["k8s"] = err.Error()
+				w.WriteHeader(http.StatusServiceUnavailable)
+				json.NewEncoder(w).Encode(status)
+				return
+			}
+			status["k8s"] = "connected"
+		}
 		w.WriteHeader(http.StatusOK)
-		w.Write([]byte(`{"status":"ok"}`))
+		json.NewEncoder(w).Encode(status)
 	})
 
 	a.server = &http.Server{
@@ -135,7 +149,28 @@ func (a *App) handleEvent(eventType string, payload []byte) {
 	}
 }
 
-// buildJobHandler creates the LLM backend and executor, then returns a handler
+// initExecutor creates the executor based on config and stores it in a.executor.
+func (a *App) initExecutor() {
+	switch a.cfg.Executor.DefaultType {
+	case "kubernetes":
+		k8sCfg := a.cfg.Executor.Kubernetes
+		k8sExec, err := executor.NewKubernetes(
+			k8sCfg.Namespace, k8sCfg.Image,
+			k8sCfg.SecretName, k8sCfg.GitSecretName,
+			k8sCfg.CPU, k8sCfg.Memory,
+		)
+		if err != nil {
+			slog.Error("failed to create k8s executor, falling back to docker", "error", err)
+			a.executor = executor.NewDocker(a.cfg.Executor.Docker.Image)
+		} else {
+			a.executor = k8sExec
+		}
+	default:
+		a.executor = executor.NewDocker(a.cfg.Executor.Docker.Image)
+	}
+}
+
+// buildJobHandler creates the LLM backend and returns a handler
 // that clones the repo, builds pipeline state, and runs the pipeline engine.
 func (a *App) buildJobHandler() worker.JobHandler {
 	// Create LLM backend based on config.
@@ -147,24 +182,7 @@ func (a *App) buildJobHandler() worker.JobHandler {
 		backend = llm.NewClaude(a.cfg.LLM.Claude.APIKey, a.cfg.LLM.Claude.Model)
 	}
 
-	// Create executor based on config.
-	var exec executor.Executor
-	switch a.cfg.Executor.DefaultType {
-	case "kubernetes":
-		k8sCfg := a.cfg.Executor.Kubernetes
-		var err error
-		exec, err = executor.NewKubernetes(
-			k8sCfg.Namespace, k8sCfg.Image,
-			k8sCfg.SecretName, k8sCfg.GitSecretName,
-			k8sCfg.CPU, k8sCfg.Memory,
-		)
-		if err != nil {
-			slog.Error("failed to create k8s executor, falling back to docker", "error", err)
-			exec = executor.NewDocker(a.cfg.Executor.Docker.Image)
-		}
-	default:
-		exec = executor.NewDocker(a.cfg.Executor.Docker.Image)
-	}
+	exec := a.executor
 
 	return func(ctx context.Context, job store.Job) error {
 		slog.Info("processing job", "job_id", job.ID, "repo", job.RepoFullName, "issue", job.IssueNumber)

--- a/internal/app/health_test.go
+++ b/internal/app/health_test.go
@@ -1,0 +1,125 @@
+package app
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/mandadapu/neuralforge/internal/executor"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// mockExecutor is a minimal executor that does not implement HealthChecker.
+type mockExecutor struct{}
+
+func (m *mockExecutor) Run(ctx context.Context, job executor.ExecutorJob) (executor.ExecutorResult, error) {
+	return executor.ExecutorResult{}, nil
+}
+func (m *mockExecutor) Cleanup(ctx context.Context, jobID string) error { return nil }
+func (m *mockExecutor) Name() string                                    { return "mock" }
+
+// healthyK8sExecutor implements both Executor and HealthChecker (Ping succeeds).
+type healthyK8sExecutor struct{ mockExecutor }
+
+func (h *healthyK8sExecutor) Ping(ctx context.Context) error { return nil }
+
+// unhealthyK8sExecutor implements both Executor and HealthChecker (Ping fails).
+type unhealthyK8sExecutor struct{ mockExecutor }
+
+func (u *unhealthyK8sExecutor) Ping(ctx context.Context) error {
+	return fmt.Errorf("k8s cluster unreachable: connection refused")
+}
+
+func TestHealthEndpoint_NoHealthChecker(t *testing.T) {
+	a := &App{executor: &mockExecutor{}}
+	mux := http.NewServeMux()
+	mux.HandleFunc("/health", func(w http.ResponseWriter, r *http.Request) {
+		status := map[string]string{"status": "ok"}
+		if hc, ok := a.executor.(executor.HealthChecker); ok {
+			if err := hc.Ping(r.Context()); err != nil {
+				status["status"] = "degraded"
+				status["k8s"] = err.Error()
+				w.WriteHeader(http.StatusServiceUnavailable)
+				json.NewEncoder(w).Encode(status)
+				return
+			}
+			status["k8s"] = "connected"
+		}
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(status)
+	})
+
+	req := httptest.NewRequest("GET", "/health", nil)
+	rr := httptest.NewRecorder()
+	mux.ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusOK, rr.Code)
+	var resp map[string]string
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &resp))
+	assert.Equal(t, "ok", resp["status"])
+	assert.Empty(t, resp["k8s"])
+}
+
+func TestHealthEndpoint_K8sHealthy(t *testing.T) {
+	a := &App{executor: &healthyK8sExecutor{}}
+	mux := http.NewServeMux()
+	mux.HandleFunc("/health", func(w http.ResponseWriter, r *http.Request) {
+		status := map[string]string{"status": "ok"}
+		if hc, ok := a.executor.(executor.HealthChecker); ok {
+			if err := hc.Ping(r.Context()); err != nil {
+				status["status"] = "degraded"
+				status["k8s"] = err.Error()
+				w.WriteHeader(http.StatusServiceUnavailable)
+				json.NewEncoder(w).Encode(status)
+				return
+			}
+			status["k8s"] = "connected"
+		}
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(status)
+	})
+
+	req := httptest.NewRequest("GET", "/health", nil)
+	rr := httptest.NewRecorder()
+	mux.ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusOK, rr.Code)
+	var resp map[string]string
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &resp))
+	assert.Equal(t, "ok", resp["status"])
+	assert.Equal(t, "connected", resp["k8s"])
+}
+
+func TestHealthEndpoint_K8sUnhealthy(t *testing.T) {
+	a := &App{executor: &unhealthyK8sExecutor{}}
+	mux := http.NewServeMux()
+	mux.HandleFunc("/health", func(w http.ResponseWriter, r *http.Request) {
+		status := map[string]string{"status": "ok"}
+		if hc, ok := a.executor.(executor.HealthChecker); ok {
+			if err := hc.Ping(r.Context()); err != nil {
+				status["status"] = "degraded"
+				status["k8s"] = err.Error()
+				w.WriteHeader(http.StatusServiceUnavailable)
+				json.NewEncoder(w).Encode(status)
+				return
+			}
+			status["k8s"] = "connected"
+		}
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(status)
+	})
+
+	req := httptest.NewRequest("GET", "/health", nil)
+	rr := httptest.NewRecorder()
+	mux.ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusServiceUnavailable, rr.Code)
+	var resp map[string]string
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &resp))
+	assert.Equal(t, "degraded", resp["status"])
+	assert.Contains(t, resp["k8s"], "k8s cluster unreachable")
+}

--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -28,3 +28,9 @@ type Executor interface {
 	Cleanup(ctx context.Context, jobID string) error
 	Name() string
 }
+
+// HealthChecker is optionally implemented by executors that can verify
+// connectivity to their backing infrastructure.
+type HealthChecker interface {
+	Ping(ctx context.Context) error
+}

--- a/internal/executor/kubernetes.go
+++ b/internal/executor/kubernetes.go
@@ -76,6 +76,16 @@ func NewKubernetesWithClient(client kubernetes.Interface, namespace, image, secr
 
 func (k *KubernetesExecutor) Name() string { return "kubernetes" }
 
+// Ping verifies connectivity to the Kubernetes cluster by fetching the
+// API server version.
+func (k *KubernetesExecutor) Ping(ctx context.Context) error {
+	_, err := k.client.Discovery().ServerVersion()
+	if err != nil {
+		return fmt.Errorf("k8s cluster unreachable: %w", err)
+	}
+	return nil
+}
+
 // jobName converts a job ID into a DNS-safe Kubernetes job name.
 // Lowercase, non-alphanumeric chars replaced with "-", max 63 chars.
 func (k *KubernetesExecutor) jobName(id string) string {
@@ -122,7 +132,8 @@ fi
 			ActiveDeadlineSeconds: &deadlineSeconds,
 			Template: corev1.PodTemplateSpec{
 				Spec: corev1.PodSpec{
-					RestartPolicy: corev1.RestartPolicyNever,
+					ServiceAccountName: "neuralforge",
+					RestartPolicy:      corev1.RestartPolicyNever,
 					InitContainers: []corev1.Container{
 						{
 							Name:  "git-clone",

--- a/internal/executor/kubernetes_test.go
+++ b/internal/executor/kubernetes_test.go
@@ -1,11 +1,13 @@
 package executor
 
 import (
+	"context"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"k8s.io/client-go/kubernetes/fake"
 )
 
 func TestK8sJobSpec(t *testing.T) {
@@ -55,4 +57,31 @@ func TestK8sJobName(t *testing.T) {
 	k := &KubernetesExecutor{}
 	assert.Equal(t, "neuralforge-owner-repo-42", k.jobName("owner/repo#42"))
 	assert.Equal(t, "neuralforge-simple", k.jobName("simple"))
+}
+
+func TestK8sPing(t *testing.T) {
+	client := fake.NewSimpleClientset()
+	k := NewKubernetesWithClient(client, "ns", "img", "secret", "git-secret", "1", "1Gi")
+	err := k.Ping(context.Background())
+	assert.NoError(t, err)
+}
+
+func TestK8sJobSpecServiceAccount(t *testing.T) {
+	k := &KubernetesExecutor{
+		namespace:     "ns",
+		image:         "img:v1",
+		secretName:    "secret",
+		gitSecretName: "git-secret",
+		cpu:           "1",
+		memory:        "1Gi",
+	}
+	job := ExecutorJob{
+		ID:       "job-1",
+		RepoPath: "owner/repo",
+		Branch:   "neuralforge/issue-1",
+		Prompt:   "test",
+		Timeout:  10 * time.Minute,
+	}
+	k8sJob := k.buildJobSpec(job)
+	assert.Equal(t, "neuralforge", k8sJob.Spec.Template.Spec.ServiceAccountName)
 }


### PR DESCRIPTION
## Implementation for #18

**Issue:** LOW: Missing RBAC docs and health check for K8s

### Approved Plan
Now I have a full picture. Here's the implementation plan:

---

### Approach

Two changes are needed:

1. **RBAC documentation**: Create a `deploy/rbac.yaml` manifest documenting the ServiceAccount, Role, and RoleBinding required for the K8s executor to create/get/delete Jobs and Pods and read Secrets. Add a reference to it in the README's Kubernetes Executor section.

2. **Health check K8s connectivity**: Enhance the `/health` endpoint so that when the executor is configured as `kubernetes`, it performs a server version check (`client.Discovery().ServerVersion()`) against the cluster and reports the result. This requires adding a `Ping` method to the `KubernetesExecutor` (and the `Executor` interface, or checked via type assertion) and wiring it into the health handler.

### Files to Modify

1. **`deploy/rbac.yaml`** — New file. K8s ServiceAccount + Role + RoleBinding manifests.
2. **`internal/executor/executor.go`** — Add an optional `HealthChecker` interface with a `Ping(ctx) error` method.
3. **`internal/executor/kubernetes.go`** — Implement `Ping` on `KubernetesExecutor` using `client.Discovery().ServerVersion()`.
4. **`internal/app/app.go`** — Enhance `/health` handler to call the executor's `Ping` if it implements `HealthChecker`.
5. **`internal/executor/kubernetes_test.go`** — Add test for the `Ping` method.
6. **`internal/app/app_test.go`** — Add test for the enhanced health endpoint (if file exists; otherwise add to existing test file).
7. **`README.md`** — Add RBAC setup instructions to the Kubernetes Executor section.

### Implementation Steps

**Step 1: Create `deploy/rbac.yaml`**

```yaml
apiVersion: v1
kind: ServiceAccount
metadata:
  name: neuralforge
  namespace: neuralforge
---
apiVersion: rbac.authorization.k8s.io/v1
kind: Role
metadata:
  name: neuralforge-executor
  namespace: neuralforge
rules:
  - apiGroups: ["batch"]
    resources: ["jobs"]
    verbs: ["create", "get", "list", "delete"]
  - apiGroups: [""]
    resources: ["pods", "pods/log"]

### Files Changed
- `README.md`
- `deploy/rbac.yaml`
- `internal/app/app.go`
- `internal/app/health_test.go`
- `internal/executor/executor.go`
- `internal/executor/kubernetes.go`
- `internal/executor/kubernetes_test.go`

### SAST Gate Warning
Auto-fix was attempted but some findings remain:
- [SECRET] `internal/executor/kubernetes.go` — unknown

Please review manually.

---
*Created by NeuralWarden Autopilot Issues Agent*