### PR TITLE
feat: implement #7 — HIGH: K8s log reading race after job completion

### DIFF
--- a/internal/executor/kubernetes.go
+++ b/internal/executor/kubernetes.go
@@ -222,7 +222,15 @@ func (k *KubernetesExecutor) Run(ctx context.Context, job ExecutorJob) (Executor
 		return ExecutorResult{TimedOut: timedOut}, fmt.Errorf("error waiting for job: %w", err)
 	}
 
-	stdout, stderr := k.readLogs(ctx, name)
+	pod, podErr := k.waitForPodTermination(ctx, name, 60*time.Second)
+	if podErr != nil {
+		return ExecutorResult{
+			Success:  success,
+			TimedOut: timedOut,
+			Stderr:   fmt.Sprintf("failed to wait for pod: %v", podErr),
+		}, nil
+	}
+	stdout, stderr := k.readLogs(ctx, pod.Name)
 
 	return ExecutorResult{
 		Success:  success,
@@ -262,33 +270,72 @@ func (k *KubernetesExecutor) waitForCompletion(ctx context.Context, name string,
 	}
 }
 
-// readLogs finds the pod for the given job and reads the main container logs.
-func (k *KubernetesExecutor) readLogs(ctx context.Context, jobName string) (stdout string, stderr string) {
-	pods, err := k.client.CoreV1().Pods(k.namespace).List(ctx, metav1.ListOptions{
-		LabelSelector: fmt.Sprintf("job-name=%s", jobName),
-	})
-	if err != nil || len(pods.Items) == 0 {
-		return "", fmt.Sprintf("failed to list pods for job %s: %v", jobName, err)
-	}
+// waitForPodTermination polls the pod associated with the job until its phase
+// is Succeeded or Failed, ensuring the container has fully exited and logs are
+// available. This prevents the race where logs are read while the container is
+// still shutting down.
+func (k *KubernetesExecutor) waitForPodTermination(ctx context.Context, jobName string, timeout time.Duration) (*corev1.Pod, error) {
+	deadline := time.After(timeout)
+	ticker := time.NewTicker(2 * time.Second)
+	defer ticker.Stop()
 
-	podName := pods.Items[0].Name
+	for {
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-deadline:
+			return nil, fmt.Errorf("timed out waiting for pod termination for job %s", jobName)
+		case <-ticker.C:
+			pods, err := k.client.CoreV1().Pods(k.namespace).List(ctx, metav1.ListOptions{
+				LabelSelector: fmt.Sprintf("job-name=%s", jobName),
+			})
+			if err != nil {
+				return nil, fmt.Errorf("failed to list pods for job %s: %w", jobName, err)
+			}
+			if len(pods.Items) == 0 {
+				continue // pod not yet visible
+			}
+			pod := &pods.Items[0]
+			if pod.Status.Phase == corev1.PodSucceeded || pod.Status.Phase == corev1.PodFailed {
+				return pod, nil
+			}
+		}
+	}
+}
+
+// readLogs reads the main container logs for the given pod name, retrying up to
+// 3 times with exponential backoff for transient stream errors.
+func (k *KubernetesExecutor) readLogs(ctx context.Context, podName string) (stdout string, stderr string) {
 	container := "claude-executor"
-	req := k.client.CoreV1().Pods(k.namespace).GetLogs(podName, &corev1.PodLogOptions{
-		Container: container,
-	})
+	var lastErr error
 
-	stream, err := req.Stream(ctx)
-	if err != nil {
-		return "", fmt.Sprintf("failed to stream logs: %v", err)
+	for attempt := 0; attempt < 3; attempt++ {
+		if attempt > 0 {
+			select {
+			case <-ctx.Done():
+				return "", fmt.Sprintf("context cancelled reading logs: %v", ctx.Err())
+			case <-time.After(time.Duration(attempt) * 2 * time.Second):
+			}
+		}
+
+		req := k.client.CoreV1().Pods(k.namespace).GetLogs(podName, &corev1.PodLogOptions{
+			Container: container,
+		})
+		stream, err := req.Stream(ctx)
+		if err != nil {
+			lastErr = err
+			continue
+		}
+		data, err := io.ReadAll(stream)
+		stream.Close()
+		if err != nil {
+			lastErr = err
+			continue
+		}
+		return string(data), ""
 	}
-	defer stream.Close()
 
-	data, err := io.ReadAll(stream)
-	if err != nil {
-		return "", fmt.Sprintf("failed to read logs: %v", err)
-	}
-
-	return string(data), ""
+	return "", fmt.Sprintf("failed to read logs after 3 attempts: %v", lastErr)
 }
 
 // Cleanup deletes the Kubernetes Job and its pods using background propagation.

--- a/internal/executor/kubernetes_test.go
+++ b/internal/executor/kubernetes_test.go
@@ -1,11 +1,15 @@
 package executor
 
 import (
+	"context"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
 )
 
 func TestK8sJobSpec(t *testing.T) {
@@ -55,4 +59,126 @@ func TestK8sJobName(t *testing.T) {
 	k := &KubernetesExecutor{}
 	assert.Equal(t, "neuralforge-owner-repo-42", k.jobName("owner/repo#42"))
 	assert.Equal(t, "neuralforge-simple", k.jobName("simple"))
+}
+
+func TestReadLogsAfterPodTermination(t *testing.T) {
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "neuralforge-job-1-abc",
+			Namespace: "test-ns",
+			Labels:    map[string]string{"job-name": "neuralforge-job-1"},
+		},
+		Status: corev1.PodStatus{
+			Phase: corev1.PodSucceeded,
+		},
+	}
+
+	client := fake.NewSimpleClientset(pod)
+	k := NewKubernetesWithClient(client, "test-ns", "img", "secret", "git-secret", "1", "1Gi")
+
+	ctx := context.Background()
+
+	// waitForPodTermination should return immediately since pod is already Succeeded
+	resultPod, err := k.waitForPodTermination(ctx, "neuralforge-job-1", 5*time.Second)
+	require.NoError(t, err)
+	assert.Equal(t, "neuralforge-job-1-abc", resultPod.Name)
+	assert.Equal(t, corev1.PodSucceeded, resultPod.Status.Phase)
+
+	// readLogs on the fake client will return an error (fake doesn't support log streaming),
+	// but the retry logic should exhaust attempts and return the error in stderr.
+	stdout, stderr := k.readLogs(ctx, resultPod.Name)
+	assert.Empty(t, stdout)
+	assert.Contains(t, stderr, "failed to read logs after 3 attempts")
+}
+
+func TestReadLogsRetryOnStreamError(t *testing.T) {
+	// The fake client doesn't support log streaming, so every attempt will fail.
+	// This test verifies the retry logic exhausts all 3 attempts and returns
+	// a descriptive error message.
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-pod",
+			Namespace: "test-ns",
+		},
+		Status: corev1.PodStatus{
+			Phase: corev1.PodSucceeded,
+		},
+	}
+
+	client := fake.NewSimpleClientset(pod)
+	k := NewKubernetesWithClient(client, "test-ns", "img", "secret", "git-secret", "1", "1Gi")
+
+	ctx := context.Background()
+	stdout, stderr := k.readLogs(ctx, "test-pod")
+	assert.Empty(t, stdout)
+	assert.Contains(t, stderr, "failed to read logs after 3 attempts")
+}
+
+func TestWaitForPodTerminationTimeout(t *testing.T) {
+	// Pod stuck in Running — should timeout
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "stuck-pod",
+			Namespace: "test-ns",
+			Labels:    map[string]string{"job-name": "neuralforge-stuck"},
+		},
+		Status: corev1.PodStatus{
+			Phase: corev1.PodRunning,
+		},
+	}
+
+	client := fake.NewSimpleClientset(pod)
+	k := NewKubernetesWithClient(client, "test-ns", "img", "secret", "git-secret", "1", "1Gi")
+
+	ctx := context.Background()
+	// Use a short timeout to keep the test fast
+	_, err := k.waitForPodTermination(ctx, "neuralforge-stuck", 3*time.Second)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "timed out waiting for pod termination")
+}
+
+func TestWaitForPodTerminationFailedPhase(t *testing.T) {
+	// Pod in Failed phase should return immediately
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "failed-pod",
+			Namespace: "test-ns",
+			Labels:    map[string]string{"job-name": "neuralforge-failed"},
+		},
+		Status: corev1.PodStatus{
+			Phase: corev1.PodFailed,
+		},
+	}
+
+	client := fake.NewSimpleClientset(pod)
+	k := NewKubernetesWithClient(client, "test-ns", "img", "secret", "git-secret", "1", "1Gi")
+
+	ctx := context.Background()
+	resultPod, err := k.waitForPodTermination(ctx, "neuralforge-failed", 5*time.Second)
+	require.NoError(t, err)
+	assert.Equal(t, "failed-pod", resultPod.Name)
+	assert.Equal(t, corev1.PodFailed, resultPod.Status.Phase)
+}
+
+func TestWaitForPodTerminationContextCancelled(t *testing.T) {
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "running-pod",
+			Namespace: "test-ns",
+			Labels:    map[string]string{"job-name": "neuralforge-running"},
+		},
+		Status: corev1.PodStatus{
+			Phase: corev1.PodRunning,
+		},
+	}
+
+	client := fake.NewSimpleClientset(pod)
+	k := NewKubernetesWithClient(client, "test-ns", "img", "secret", "git-secret", "1", "1Gi")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // cancel immediately
+
+	_, err := k.waitForPodTermination(ctx, "neuralforge-running", 30*time.Second)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, context.Canceled)
 }


### PR DESCRIPTION
## Implementation for #7

**Issue:** HIGH: K8s log reading race after job completion

### Approved Plan
Now I have a complete picture. Here's the implementation plan:

---

### Approach

Add retry logic with backoff to `readLogs()` so it waits for the pod to reach a terminal phase (`Succeeded`/`Failed`) before streaming logs. After `waitForCompletion` returns, the K8s Job is marked complete but the pod may still be in `Running` or `Terminating` state. The fix adds a `waitForPodTermination` step between `waitForCompletion` and `readLogs`, plus retry logic inside `readLogs` itself to handle transient log-streaming failures.

### Files to Modify

1. `internal/executor/kubernetes.go` — add pod-ready wait + retry logic
2. `internal/executor/kubernetes_test.go` — add tests for the new behavior

### Implementation Steps

**1. Add `waitForPodTermination` method to `KubernetesExecutor` (`kubernetes.go`)**

Insert a new method that polls the pod associated with the job until its phase is `Succeeded` or `Failed` (i.e., the container has fully exited and logs are available). This prevents the race where logs are read while the container is still shutting down.

```go
func (k *KubernetesExecutor) waitForPodTermination(ctx context.Context, jobName string, timeout time.Duration) (*corev1.Pod, error) {
    deadline := time.After(timeout)
    ticker := time.NewTicker(2 * time.Second)
    defer ticker.Stop()

    for {
        select {
        case <-ctx.Done():
            return nil, ctx.Err()
        case <-deadline:
            return nil, fmt.Errorf("timed out waiting for pod termination for job %s", jobName)
        case <-ticker.C:
            pods, err := k.client.CoreV1().Pods(k.namespace).List(ctx, metav1.ListOptions{
                LabelSelector: fmt.Sprintf("job-name=%s", jobName),
            })
            if err != nil {
                return nil, fmt.Errorf("failed to list pods for job %s: %w", jobName, err)
            }
            if len(pods.Items) == 0 {
                continue // pod not yet visible
            }
            pod := &pods.Items[0]
            if

### Files Changed
- `internal/executor/kubernetes.go`
- `internal/executor/kubernetes_test.go`

### SAST Gate Warning
Auto-fix was attempted but some findings remain:
- [SECRET] `internal/executor/kubernetes.go` — unknown

Please review manually.

---
*Created by NeuralWarden Autopilot Issues Agent*