### PR TITLE
feat: implement #10 — HIGH: Webhook returns 200 OK even when job creation fails

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -102,20 +102,19 @@ func (a *App) Shutdown(ctx context.Context) error {
 }
 
 // handleEvent parses a webhook event and creates a job for issue labeled events.
-func (a *App) handleEvent(eventType string, payload []byte) {
+func (a *App) handleEvent(eventType string, payload []byte) error {
 	event, err := github.ParseWebhookEvent(eventType, payload)
 	if err != nil {
-		slog.Error("parse webhook event", "error", err)
-		return
+		return fmt.Errorf("parse webhook event: %w", err)
 	}
 	if event == nil {
-		return
+		return nil
 	}
 
 	switch e := event.(type) {
 	case *github.IssueLabeledEvent:
 		if e.Label != "neuralforge" {
-			return
+			return nil
 		}
 		jobID := fmt.Sprintf("%s#%d", e.Repo.FullName, e.Issue.Number)
 		job := store.Job{
@@ -126,12 +125,13 @@ func (a *App) handleEvent(eventType string, payload []byte) {
 			Status:       store.JobQueued,
 		}
 		if err := a.store.CreateJob(job); err != nil {
-			slog.Error("create job", "error", err, "job_id", jobID)
-			return
+			return fmt.Errorf("create job %s: %w", jobID, err)
 		}
 		slog.Info("job created", "job_id", jobID, "issue", e.Issue.Title)
+		return nil
 	default:
 		slog.Info("unhandled event type", "type", event.EventType())
+		return nil
 	}
 }
 

--- a/internal/app/webhook.go
+++ b/internal/app/webhook.go
@@ -5,11 +5,12 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"io"
+	"log/slog"
 	"net/http"
 	"strings"
 )
 
-type EventCallback func(eventType string, payload []byte)
+type EventCallback func(eventType string, payload []byte) error
 
 type WebhookHandler struct {
 	secret   string
@@ -34,7 +35,11 @@ func (h *WebhookHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	eventType := r.Header.Get("X-GitHub-Event")
-	go h.callback(eventType, body)
+	if err := h.callback(eventType, body); err != nil {
+		slog.Error("webhook callback failed", "event", eventType, "error", err)
+		http.Error(w, `{"error":"internal"}`, http.StatusInternalServerError)
+		return
+	}
 
 	w.WriteHeader(http.StatusOK)
 	w.Write([]byte(`{"ok":true}`))

--- a/internal/app/webhook_test.go
+++ b/internal/app/webhook_test.go
@@ -4,6 +4,7 @@ import (
 	"crypto/hmac"
 	"crypto/sha256"
 	"encoding/hex"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -20,7 +21,7 @@ func TestWebhookSignatureValidation(t *testing.T) {
 	mac.Write([]byte(body))
 	sig := "sha256=" + hex.EncodeToString(mac.Sum(nil))
 
-	handler := NewWebhookHandler(secret, func(eventType string, payload []byte) {})
+	handler := NewWebhookHandler(secret, func(eventType string, payload []byte) error { return nil })
 
 	req := httptest.NewRequest("POST", "/webhooks/github", strings.NewReader(body))
 	req.Header.Set("X-Hub-Signature-256", sig)
@@ -33,7 +34,7 @@ func TestWebhookSignatureValidation(t *testing.T) {
 }
 
 func TestWebhookRejectsInvalidSignature(t *testing.T) {
-	handler := NewWebhookHandler("secret", func(eventType string, payload []byte) {})
+	handler := NewWebhookHandler("secret", func(eventType string, payload []byte) error { return nil })
 
 	req := httptest.NewRequest("POST", "/webhooks/github", strings.NewReader("{}"))
 	req.Header.Set("X-Hub-Signature-256", "sha256=invalid")
@@ -43,4 +44,26 @@ func TestWebhookRejectsInvalidSignature(t *testing.T) {
 	handler.ServeHTTP(rr, req)
 
 	assert.Equal(t, http.StatusUnauthorized, rr.Code)
+}
+
+func TestWebhookReturns500OnCallbackError(t *testing.T) {
+	secret := "test-secret"
+	body := `{"action":"labeled"}`
+
+	mac := hmac.New(sha256.New, []byte(secret))
+	mac.Write([]byte(body))
+	sig := "sha256=" + hex.EncodeToString(mac.Sum(nil))
+
+	handler := NewWebhookHandler(secret, func(eventType string, payload []byte) error {
+		return fmt.Errorf("job creation failed")
+	})
+
+	req := httptest.NewRequest("POST", "/webhooks/github", strings.NewReader(body))
+	req.Header.Set("X-Hub-Signature-256", sig)
+	req.Header.Set("X-GitHub-Event", "issues")
+
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusInternalServerError, rr.Code)
 }


### PR DESCRIPTION
## Implementation for #10

**Issue:** HIGH: Webhook returns 200 OK even when job creation fails

### Approved Plan
Now I have a complete picture. Here's the implementation plan:

---

### Approach

Make the webhook callback **synchronous** so errors from event parsing and job creation propagate back to the HTTP response. The callback itself (`handleEvent`) is lightweight — it only parses JSON and inserts a DB row — so running it inline won't risk GitHub's 10-second webhook timeout. The heavy pipeline work already runs asynchronously via the worker pool.

Change the `EventCallback` signature to return an `error`, run the callback inline (remove the goroutine), and map errors to appropriate HTTP status codes.

### Files to Modify

1. **`internal/app/webhook.go`** — Change callback signature, run synchronously, return error-based HTTP status
2. **`internal/app/app.go`** — Update `handleEvent` to return an `error` instead of silently logging
3. **`internal/app/webhook_test.go`** — Update tests for new callback signature; add test for callback error → 500

### Implementation Steps

**Step 1: `internal/app/webhook.go`**

Change the `EventCallback` type signature from `func(string, []byte)` to `func(string, []byte) error`:

```go
type EventCallback func(eventType string, payload []byte) error
```

In `ServeHTTP`, replace the async goroutine + unconditional 200 OK (lines 37–40) with a synchronous call that checks the error:

```go
eventType := r.Header.Get("X-GitHub-Event")
if err := h.callback(eventType, payload); err != nil {
    slog.Error("webhook callback failed", "event", eventType, "error", err)
    http.Error(w, `{"error":"internal"}`, http.StatusInternalServerError)
    return
}

w.WriteHeader(http.StatusOK)
w.Write([]byte(`{"ok":true}`))
```

Add `"log/slog"` to imports.

**Step 2: `internal/app/app.go`**

Change `handleEvent` signature (line 105) from:
```go
func (a *App) handleEvent(eventType string, payload []byte) {
```
to:
```go
func (a *App) handleEvent(eventType string, payload []byte) error {
```

Replace each bare `return` with an error return:
- Line 108–109 (parse e

### Files Changed
- `internal/app/app.go`
- `internal/app/webhook.go`
- `internal/app/webhook_test.go`

---
*Created by NeuralWarden Autopilot Issues Agent*