### PR TITLE
feat: implement #8 — HIGH: Missing input validation on repo and branch names

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -17,6 +17,7 @@ import (
 	"github.com/mandadapu/neuralforge/internal/llm"
 	"github.com/mandadapu/neuralforge/internal/pipeline"
 	"github.com/mandadapu/neuralforge/internal/store"
+	"github.com/mandadapu/neuralforge/internal/validate"
 	"github.com/mandadapu/neuralforge/internal/worker"
 )
 
@@ -115,6 +116,10 @@ func (a *App) handleEvent(eventType string, payload []byte) {
 	switch e := event.(type) {
 	case *github.IssueLabeledEvent:
 		if e.Label != "neuralforge" {
+			return
+		}
+		if err := validate.RepoFullName(e.Repo.FullName); err != nil {
+			slog.Error("invalid repo name from webhook", "error", err, "repo", e.Repo.FullName)
 			return
 		}
 		jobID := fmt.Sprintf("%s#%d", e.Repo.FullName, e.Issue.Number)

--- a/internal/executor/kubernetes.go
+++ b/internal/executor/kubernetes.go
@@ -8,6 +8,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/mandadapu/neuralforge/internal/validate"
+
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -90,7 +92,14 @@ func (k *KubernetesExecutor) jobName(id string) string {
 }
 
 // buildJobSpec constructs the Kubernetes Job spec for the given ExecutorJob.
-func (k *KubernetesExecutor) buildJobSpec(job ExecutorJob) *batchv1.Job {
+func (k *KubernetesExecutor) buildJobSpec(job ExecutorJob) (*batchv1.Job, error) {
+	if err := validate.RepoFullName(job.RepoPath); err != nil {
+		return nil, fmt.Errorf("unsafe repo path: %w", err)
+	}
+	if err := validate.BranchName(job.Branch); err != nil {
+		return nil, fmt.Errorf("unsafe branch name: %w", err)
+	}
+
 	backoffLimit := int32(0)
 	deadlineSeconds := int64(job.Timeout.Seconds())
 
@@ -114,7 +123,7 @@ fi
 			Namespace: k.namespace,
 			Labels: map[string]string{
 				"app":    "neuralforge",
-				"job-id": job.ID,
+				"job-id": k.jobName(job.ID),
 			},
 		},
 		Spec: batchv1.JobSpec{
@@ -203,13 +212,16 @@ fi
 				},
 			},
 		},
-	}
+	}, nil
 }
 
 // Run creates a Kubernetes Job, waits for completion, reads logs, and returns
 // the result.
 func (k *KubernetesExecutor) Run(ctx context.Context, job ExecutorJob) (ExecutorResult, error) {
-	k8sJob := k.buildJobSpec(job)
+	k8sJob, err := k.buildJobSpec(job)
+	if err != nil {
+		return ExecutorResult{}, fmt.Errorf("build job spec: %w", err)
+	}
 
 	created, err := k.client.BatchV1().Jobs(k.namespace).Create(ctx, k8sJob, metav1.CreateOptions{})
 	if err != nil {

--- a/internal/executor/kubernetes_test.go
+++ b/internal/executor/kubernetes_test.go
@@ -27,7 +27,8 @@ func TestK8sJobSpec(t *testing.T) {
 		Timeout:  30 * time.Minute,
 	}
 
-	k8sJob := k.buildJobSpec(job)
+	k8sJob, err := k.buildJobSpec(job)
+	require.NoError(t, err)
 
 	assert.Equal(t, "neuralforge-job-42", k8sJob.Name)
 	assert.Equal(t, "forge-ns", k8sJob.Namespace)
@@ -49,10 +50,61 @@ func TestK8sJobSpec(t *testing.T) {
 
 	require.Len(t, k8sJob.Spec.Template.Spec.Volumes, 1)
 	assert.Equal(t, "workspace", k8sJob.Spec.Template.Spec.Volumes[0].Name)
+
+	// Verify label is sanitized
+	assert.Equal(t, "neuralforge-job-42", k8sJob.Labels["job-id"])
 }
 
 func TestK8sJobName(t *testing.T) {
 	k := &KubernetesExecutor{}
 	assert.Equal(t, "neuralforge-owner-repo-42", k.jobName("owner/repo#42"))
 	assert.Equal(t, "neuralforge-simple", k.jobName("simple"))
+}
+
+func TestBuildJobSpec_InvalidRepoPath(t *testing.T) {
+	k := &KubernetesExecutor{
+		namespace:     "forge-ns",
+		image:         "claude-exec:v1",
+		secretName:    "llm-keys",
+		gitSecretName: "git-token",
+		cpu:           "2",
+		memory:        "4Gi",
+	}
+
+	job := ExecutorJob{
+		ID:       "job-1",
+		RepoPath: "$(evil)",
+		Branch:   "neuralforge/issue-1",
+		Prompt:   "Do something",
+		Timeout:  10 * time.Minute,
+	}
+
+	result, err := k.buildJobSpec(job)
+	assert.Nil(t, result)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "unsafe repo path")
+}
+
+func TestBuildJobSpec_InvalidBranch(t *testing.T) {
+	k := &KubernetesExecutor{
+		namespace:     "forge-ns",
+		image:         "claude-exec:v1",
+		secretName:    "llm-keys",
+		gitSecretName: "git-token",
+		cpu:           "2",
+		memory:        "4Gi",
+	}
+
+	job := ExecutorJob{
+		ID:       "job-1",
+		RepoPath: "owner/repo",
+		Branch:   "; rm -rf /",
+		Prompt:   "Do something",
+		Timeout:  10 * time.Minute,
+	}
+
+	result, err := k.buildJobSpec(job)
+	assert.Nil(t, result)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "unsafe branch name")
 }

--- a/internal/validate/validate.go
+++ b/internal/validate/validate.go
@@ -1,0 +1,50 @@
+package validate
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+// repoNameRe matches "owner/repo" where both parts are GitHub-valid:
+// alphanumeric, hyphens, dots, underscores; 1-100 chars each.
+var repoNameRe = regexp.MustCompile(`^[a-zA-Z0-9._-]{1,100}/[a-zA-Z0-9._-]{1,100}$`)
+
+// branchRe matches safe git branch names: alphanumeric, hyphens, underscores,
+// dots, slashes — no shell metacharacters, no "..", no leading/trailing dots.
+var branchRe = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9/_.-]{0,248}[a-zA-Z0-9]$`)
+
+// RepoFullName validates that s is a valid "owner/repo" GitHub identifier.
+func RepoFullName(s string) error {
+	if !repoNameRe.MatchString(s) {
+		return fmt.Errorf("invalid repo full name %q: must match owner/repo", s)
+	}
+	return nil
+}
+
+// BranchName validates that s is safe for use as a git branch name.
+// Rejects shell metacharacters, "..", and whitespace.
+func BranchName(s string) error {
+	if len(s) < 1 || len(s) > 250 {
+		return fmt.Errorf("invalid branch name %q: length must be 1-250", s)
+	}
+	if strings.Contains(s, "..") {
+		return fmt.Errorf("invalid branch name %q: contains '..'", s)
+	}
+	if !branchRe.MatchString(s) {
+		return fmt.Errorf("invalid branch name %q: contains unsafe characters", s)
+	}
+	return nil
+}
+
+// JobID validates that s is a well-formed job ID (owner/repo#number).
+func JobID(s string) error {
+	parts := strings.SplitN(s, "#", 2)
+	if len(parts) != 2 {
+		return fmt.Errorf("invalid job ID %q: must contain '#'", s)
+	}
+	if err := RepoFullName(parts[0]); err != nil {
+		return fmt.Errorf("invalid job ID %q: %w", s, err)
+	}
+	return nil
+}

--- a/internal/validate/validate_test.go
+++ b/internal/validate/validate_test.go
@@ -1,0 +1,98 @@
+package validate
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRepoFullName(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		wantErr bool
+	}{
+		{"valid simple", "owner/repo", false},
+		{"valid with special chars", "my-org/my.repo_1", false},
+		{"valid with dots", "org.name/repo.name", false},
+		{"empty string", "", true},
+		{"no slash", "noslash", true},
+		{"too many slashes", "a/b/c", true},
+		{"shell injection", "owner/repo; rm -rf /", true},
+		{"command substitution", "$(evil)/repo", true},
+		{"backtick injection", "`evil`/repo", true},
+		{"space in name", "owner/ repo", true},
+		{"newline in name", "owner/repo\n", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := RepoFullName(tt.input)
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestBranchName(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		wantErr bool
+	}{
+		{"valid neuralforge branch", "neuralforge/issue-42", false},
+		{"valid main", "main", false},
+		{"valid feature branch", "feat/x.y", false},
+		{"valid with underscore", "feature_branch", false},
+		{"empty string", "", true},
+		{"command substitution", "$(cmd)", true},
+		{"backtick injection", "`cmd`", true},
+		{"double dot", "a..b", true},
+		{"space in name", "branch name", true},
+		{"semicolon injection", "; rm -rf /", true},
+		{"pipe injection", "main|evil", true},
+		{"too long", strings.Repeat("a", 251), true},
+		{"single char", "a", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := BranchName(tt.input)
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestJobID(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		wantErr bool
+	}{
+		{"valid job ID", "owner/repo#42", false},
+		{"valid with special chars", "my-org/my.repo_1#123", false},
+		{"no hash", "nohash", true},
+		{"invalid repo part", "bad name#1", true},
+		{"missing number part", "owner/repo", true},
+		{"shell injection in repo", "$(evil)/repo#1", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := JobID(tt.input)
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Implementation for #8

**Issue:** HIGH: Missing input validation on repo and branch names

### Approved Plan
Now I have a complete picture. Here is the implementation plan:

---

### Approach

Create a centralized `internal/validate` package with pure validation functions for repo full names, branch names, and job IDs. Apply validation at the system boundary — in `internal/app/app.go` when webhook events arrive, and as defensive checks in the Kubernetes executor where unsanitized values are interpolated into shell scripts. This eliminates both panic risk and shell/git injection vectors.

### Files to Modify

1. **`internal/validate/validate.go`** (new) — Validation functions
2. **`internal/validate/validate_test.go`** (new) — Table-driven tests
3. **`internal/app/app.go`** — Validate at the entry point (webhook handler)
4. **`internal/executor/kubernetes.go`** — Defensive validation in `buildJobSpec` + sanitize label value
5. **`internal/executor/kubernetes_test.go`** — Add tests for invalid inputs

### Implementation Steps

**Step 1: Create `internal/validate/validate.go`**

```go
package validate

import (
    "fmt"
    "regexp"
    "strings"
)

// repoNameRe matches "owner/repo" where both parts are GitHub-valid:
// alphanumeric, hyphens, dots, underscores; 1-100 chars each.
var repoNameRe = regexp.MustCompile(`^[a-zA-Z0-9._-]{1,100}/[a-zA-Z0-9._-]{1,100}$`)

// branchRe matches safe git branch names: alphanumeric, hyphens, underscores,
// dots, slashes — no shell metacharacters, no "..", no leading/trailing dots.
var branchRe = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9/_.-]{0,248}[a-zA-Z0-9]$`)

// dnsLabelRe matches DNS-safe label values (Kubernetes label constraint).
var dnsLabelRe = regexp.MustCompile(`^[a-z0-9]([a-z0-9._-]{0,61}[a-z0-9])?$`)

// RepoFullName validates that s is a valid "owner/repo" GitHub identifier.
func RepoFullName(s string) error {
    if !repoNameRe.MatchString(s) {
        return fmt.Errorf("invalid repo full name %q: must match owner/repo", s)
    }
    return nil
}

// BranchName validates that s is safe for use as a git branch name.
// Re

### Files Changed
- `internal/app/app.go`
- `internal/executor/kubernetes.go`
- `internal/executor/kubernetes_test.go`
- `internal/validate/validate.go`
- `internal/validate/validate_test.go`

### SAST Gate Warning
Auto-fix was attempted but some findings remain:
- [SECRET] `internal/executor/kubernetes.go` — unknown

Please review manually.

---
*Created by NeuralWarden Autopilot Issues Agent*