### PR TITLE
feat: implement #9 — HIGH: No retry logic for LLM API calls

### DIFF
--- a/internal/llm/claude.go
+++ b/internal/llm/claude.go
@@ -69,7 +69,9 @@ func (c *ClaudeBackend) Complete(ctx context.Context, req CompletionRequest) (Co
 		params.Temperature = param.NewOpt(req.Temperature)
 	}
 
-	resp, err := c.client.Messages.New(ctx, params)
+	resp, err := withRetry(ctx, DefaultRetryConfig, func() (*anthropic.Message, error) {
+		return c.client.Messages.New(ctx, params)
+	})
 	if err != nil {
 		return CompletionResponse{}, fmt.Errorf("claude completion failed: %w", err)
 	}

--- a/internal/llm/openai.go
+++ b/internal/llm/openai.go
@@ -61,7 +61,9 @@ func (o *OpenAIBackend) Complete(ctx context.Context, req CompletionRequest) (Co
 		params.Temperature = param.NewOpt(req.Temperature)
 	}
 
-	resp, err := o.client.Chat.Completions.New(ctx, params)
+	resp, err := withRetry(ctx, DefaultRetryConfig, func() (*openai.ChatCompletion, error) {
+		return o.client.Chat.Completions.New(ctx, params)
+	})
 	if err != nil {
 		return CompletionResponse{}, fmt.Errorf("openai completion failed: %w", err)
 	}

--- a/internal/llm/retry.go
+++ b/internal/llm/retry.go
@@ -1,0 +1,85 @@
+package llm
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log"
+	"math"
+	"net"
+	"strings"
+	"time"
+)
+
+// RetryConfig controls retry behavior for LLM API calls.
+type RetryConfig struct {
+	MaxAttempts int
+	BaseDelay   time.Duration
+	Multiplier  float64
+}
+
+// DefaultRetryConfig provides sensible defaults: 3 attempts with exponential backoff
+// starting at 500ms (delays: 500ms, 1s, then fail).
+var DefaultRetryConfig = RetryConfig{
+	MaxAttempts: 3,
+	BaseDelay:   500 * time.Millisecond,
+	Multiplier:  2.0,
+}
+
+// isTransient returns true if the error is likely transient and worth retrying.
+func isTransient(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	// Network errors (timeout, connection refused, DNS)
+	var netErr net.Error
+	if errors.As(err, &netErr) {
+		return true
+	}
+
+	// Rate limit and server errors detected by message content.
+	// Both anthropic-sdk-go and openai-go wrap HTTP errors with status codes.
+	msg := strings.ToLower(err.Error())
+	for _, substr := range []string{"429", "500", "502", "503", "529", "rate", "overloaded"} {
+		if strings.Contains(msg, substr) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// withRetry executes fn up to cfg.MaxAttempts times, retrying on transient errors
+// with exponential backoff. Permanent errors are returned immediately.
+func withRetry[T any](ctx context.Context, cfg RetryConfig, fn func() (T, error)) (T, error) {
+	var lastErr error
+	var zero T
+
+	for attempt := 0; attempt < cfg.MaxAttempts; attempt++ {
+		result, err := fn()
+		if err == nil {
+			return result, nil
+		}
+
+		lastErr = err
+
+		if !isTransient(err) {
+			return zero, err
+		}
+
+		if attempt < cfg.MaxAttempts-1 {
+			delay := time.Duration(float64(cfg.BaseDelay) * math.Pow(cfg.Multiplier, float64(attempt)))
+			log.Printf("llm: transient error (attempt %d/%d), retrying in %v: %v",
+				attempt+1, cfg.MaxAttempts, delay, err)
+
+			select {
+			case <-ctx.Done():
+				return zero, ctx.Err()
+			case <-time.After(delay):
+			}
+		}
+	}
+
+	return zero, fmt.Errorf("all %d attempts failed: %w", cfg.MaxAttempts, lastErr)
+}

--- a/internal/llm/retry_test.go
+++ b/internal/llm/retry_test.go
@@ -1,0 +1,231 @@
+package llm
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// testNetError implements net.Error for testing transient network errors.
+type testNetError struct {
+	msg string
+}
+
+func (e *testNetError) Error() string   { return e.msg }
+func (e *testNetError) Timeout() bool   { return true }
+func (e *testNetError) Temporary() bool { return true }
+
+// Verify it satisfies net.Error.
+var _ net.Error = (*testNetError)(nil)
+
+func TestIsTransient(t *testing.T) {
+	tests := []struct {
+		name      string
+		err       error
+		transient bool
+	}{
+		{
+			name:      "nil error",
+			err:       nil,
+			transient: false,
+		},
+		{
+			name:      "net.Error is transient",
+			err:       &testNetError{msg: "connection refused"},
+			transient: true,
+		},
+		{
+			name:      "rate limit 429",
+			err:       fmt.Errorf("HTTP 429: rate limit exceeded"),
+			transient: true,
+		},
+		{
+			name:      "server error 500",
+			err:       fmt.Errorf("HTTP 500: internal server error"),
+			transient: true,
+		},
+		{
+			name:      "bad gateway 502",
+			err:       fmt.Errorf("HTTP 502: bad gateway"),
+			transient: true,
+		},
+		{
+			name:      "service unavailable 503",
+			err:       fmt.Errorf("HTTP 503: service unavailable"),
+			transient: true,
+		},
+		{
+			name:      "anthropic overloaded 529",
+			err:       fmt.Errorf("HTTP 529: overloaded"),
+			transient: true,
+		},
+		{
+			name:      "rate limit keyword",
+			err:       fmt.Errorf("rate limit exceeded, please retry"),
+			transient: true,
+		},
+		{
+			name:      "overloaded keyword",
+			err:       fmt.Errorf("API is overloaded"),
+			transient: true,
+		},
+		{
+			name:      "auth error 401 not transient",
+			err:       fmt.Errorf("HTTP 401: unauthorized"),
+			transient: false,
+		},
+		{
+			name:      "invalid api key not transient",
+			err:       fmt.Errorf("invalid api key"),
+			transient: false,
+		},
+		{
+			name:      "bad request 400 not transient",
+			err:       fmt.Errorf("HTTP 400: bad request"),
+			transient: false,
+		},
+		{
+			name:      "generic error not transient",
+			err:       fmt.Errorf("something went wrong"),
+			transient: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.transient, isTransient(tt.err))
+		})
+	}
+}
+
+func TestWithRetry(t *testing.T) {
+	fastCfg := RetryConfig{
+		MaxAttempts: 3,
+		BaseDelay:   1 * time.Millisecond,
+		Multiplier:  2.0,
+	}
+
+	t.Run("immediate success", func(t *testing.T) {
+		calls := 0
+		result, err := withRetry(context.Background(), fastCfg, func() (string, error) {
+			calls++
+			return "ok", nil
+		})
+
+		assert.NoError(t, err)
+		assert.Equal(t, "ok", result)
+		assert.Equal(t, 1, calls)
+	})
+
+	t.Run("transient then success", func(t *testing.T) {
+		calls := 0
+		result, err := withRetry(context.Background(), fastCfg, func() (string, error) {
+			calls++
+			if calls == 1 {
+				return "", &testNetError{msg: "connection reset"}
+			}
+			return "recovered", nil
+		})
+
+		assert.NoError(t, err)
+		assert.Equal(t, "recovered", result)
+		assert.Equal(t, 2, calls)
+	})
+
+	t.Run("permanent error no retry", func(t *testing.T) {
+		calls := 0
+		permErr := fmt.Errorf("invalid api key")
+		_, err := withRetry(context.Background(), fastCfg, func() (string, error) {
+			calls++
+			return "", permErr
+		})
+
+		assert.ErrorIs(t, err, permErr)
+		assert.Equal(t, 1, calls)
+	})
+
+	t.Run("all attempts exhausted", func(t *testing.T) {
+		calls := 0
+		transientErr := fmt.Errorf("HTTP 503: service unavailable")
+		_, err := withRetry(context.Background(), fastCfg, func() (string, error) {
+			calls++
+			return "", transientErr
+		})
+
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "all 3 attempts failed")
+		assert.ErrorIs(t, err, transientErr)
+		assert.Equal(t, 3, calls)
+	})
+
+	t.Run("context cancelled between retries", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		calls := 0
+		_, err := withRetry(ctx, fastCfg, func() (string, error) {
+			calls++
+			if calls == 1 {
+				cancel() // cancel context after first failure
+				return "", fmt.Errorf("HTTP 503: service unavailable")
+			}
+			return "should not reach", nil
+		})
+
+		assert.ErrorIs(t, err, context.Canceled)
+		assert.Equal(t, 1, calls)
+	})
+
+	t.Run("rate limit error retried", func(t *testing.T) {
+		calls := 0
+		result, err := withRetry(context.Background(), fastCfg, func() (int, error) {
+			calls++
+			if calls < 3 {
+				return 0, fmt.Errorf("HTTP 429: too many requests")
+			}
+			return 42, nil
+		})
+
+		assert.NoError(t, err)
+		assert.Equal(t, 42, result)
+		assert.Equal(t, 3, calls)
+	})
+
+	t.Run("server errors retried", func(t *testing.T) {
+		for _, code := range []string{"500", "502", "503"} {
+			t.Run(code, func(t *testing.T) {
+				calls := 0
+				result, err := withRetry(context.Background(), fastCfg, func() (string, error) {
+					calls++
+					if calls == 1 {
+						return "", fmt.Errorf("HTTP %s: server error", code)
+					}
+					return "ok", nil
+				})
+
+				assert.NoError(t, err)
+				assert.Equal(t, "ok", result)
+				assert.Equal(t, 2, calls)
+			})
+		}
+	})
+
+	t.Run("single attempt config", func(t *testing.T) {
+		singleCfg := RetryConfig{
+			MaxAttempts: 1,
+			BaseDelay:   1 * time.Millisecond,
+			Multiplier:  2.0,
+		}
+		calls := 0
+		_, err := withRetry(context.Background(), singleCfg, func() (string, error) {
+			calls++
+			return "", fmt.Errorf("HTTP 503: service unavailable")
+		})
+
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "all 1 attempts failed")
+		assert.Equal(t, 1, calls)
+	})
+}


### PR DESCRIPTION
## Implementation for #9

**Issue:** HIGH: No retry logic for LLM API calls

### Approved Plan
Now I have a complete picture of the codebase. Here's the implementation plan:

---

### Approach

Add retry with exponential backoff at the `internal/llm` package level, so all consumers (architect, security, review stages) automatically benefit. Create a new `retry.go` utility in `internal/llm/` with a generic retry function, then wrap the API calls in `claude.go` and `openai.go`. No changes needed to the pipeline stage files — the retry is transparent to callers.

### Files to Modify

1. **`internal/llm/retry.go`** — NEW: retry utility with exponential backoff and transient error classification
2. **`internal/llm/retry_test.go`** — NEW: comprehensive unit tests for retry logic
3. **`internal/llm/claude.go`** — Wrap `c.client.Messages.New()` call (line 72) with retry
4. **`internal/llm/openai.go`** — Wrap `o.client.Chat.Completions.New()` call (line 64) with retry

### Implementation Steps

**Step 1: Create `internal/llm/retry.go`**

Define a `RetryConfig` struct and a `withRetry` function (unexported, package-internal):

```go
package llm

import (
    "context"
    "log"
    "math"
    "net"
    "strings"
    "time"
)

type RetryConfig struct {
    MaxAttempts int
    BaseDelay   time.Duration
    Multiplier  float64
}

var DefaultRetryConfig = RetryConfig{
    MaxAttempts: 3,
    BaseDelay:   500 * time.Millisecond,
    Multiplier:  2.0,
}

func isTransient(err error) bool {
    if err == nil {
        return false
    }
    // Network errors (timeout, connection refused, DNS)
    var netErr net.Error
    if errors.As(err, &netErr) {
        return true
    }
    // Rate limit and server errors detected by message content
    // Both anthropic-sdk-go and openai-go wrap HTTP errors with status codes
    msg := err.Error()
    for _, substr := range []string{"429", "500", "502", "503", "529", "rate", "overloaded"} {
        if strings.Contains(strings.ToLower(msg), substr) {
            return true
        }
    }
    return false
}

func withRetry[T any](ctx con

### Files Changed
- `internal/llm/claude.go`
- `internal/llm/openai.go`
- `internal/llm/retry.go`
- `internal/llm/retry_test.go`

---
*Created by NeuralWarden Autopilot Issues Agent*