### PR TITLE
feat: implement #2 — CRITICAL: Executor cleanup never called — K8s Jobs/Pods accu

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -169,6 +169,12 @@ func (a *App) buildJobHandler() worker.JobHandler {
 	return func(ctx context.Context, job store.Job) error {
 		slog.Info("processing job", "job_id", job.ID, "repo", job.RepoFullName, "issue", job.IssueNumber)
 
+		defer func() {
+			if err := exec.Cleanup(ctx, job.ID); err != nil {
+				slog.Warn("executor cleanup failed", "job_id", job.ID, "executor", exec.Name(), "error", err)
+			}
+		}()
+
 		// 1. Create temp dir and clone the repo.
 		tmpDir, err := os.MkdirTemp("", "neuralforge-*")
 		if err != nil {


### PR DESCRIPTION
## Implementation for #2

**Issue:** CRITICAL: Executor cleanup never called — K8s Jobs/Pods accumulate

### Approved Plan
Now I have a complete picture of the issue. Here is the implementation plan:

---

### Approach

Add `defer exec.Cleanup(ctx, job.ID)` inside the `buildJobHandler` closure, immediately after the pipeline `engine.Run()` call site — specifically, right before the pipeline runs, so cleanup happens regardless of whether the pipeline succeeds or fails. The `exec` variable is already captured in the closure scope, and the `Cleanup` method exists on both `KubernetesExecutor` and `DockerExecutor` but is never called.

### Files to Modify

1. **`internal/app/app.go`** — Add the deferred cleanup call inside the returned `JobHandler` closure.

### Implementation Steps

1. **Add `defer exec.Cleanup()` in `buildJobHandler` closure** (`internal/app/app.go:169-235`)

   Inside the anonymous function returned at line 169, add a deferred cleanup call right after the executor is available and the job ID is known. The best placement is immediately inside the closure (after line 170), since `exec` and `job.ID` are both available at that point and cleanup should run regardless of how the function exits:

   ```go
   // At line 170, after the slog.Info call, add:
   defer func() {
       if err := exec.Cleanup(ctx, job.ID); err != nil {
           slog.Warn("executor cleanup failed", "job_id", job.ID, "executor", exec.Name(), "error", err)
       }
   }()
   ```

   Using a wrapper function for the defer ensures the cleanup error is logged rather than silently swallowed. Using `slog.Warn` (not `Error`) because cleanup failure is not a job-level error — the job itself may have succeeded.

   **Note on Docker**: The `DockerExecutor` uses `--rm` flag (line 23 of `docker.go`), so containers auto-remove on exit. The `Cleanup` call for Docker (`docker rm -f nf-<jobID>`) will likely return a "not found" error in the normal case. This is harmless — the warn log handles it gracefully. The `--rm` flag does not cover crash/timeout scenarios where the container may still be lingering, so calling `Cl

### Files Changed
- `internal/app/app.go`

---
*Created by NeuralWarden Autopilot Issues Agent*