### PR TITLE
feat: implement #13 — MEDIUM: K8s log reading returns errors as strings

### DIFF
--- a/internal/executor/kubernetes.go
+++ b/internal/executor/kubernetes.go
@@ -222,7 +222,11 @@ func (k *KubernetesExecutor) Run(ctx context.Context, job ExecutorJob) (Executor
 		return ExecutorResult{TimedOut: timedOut}, fmt.Errorf("error waiting for job: %w", err)
 	}
 
-	stdout, stderr := k.readLogs(ctx, name)
+	stdout, logErr := k.readLogs(ctx, name)
+	var stderr string
+	if logErr != nil {
+		stderr = fmt.Sprintf("failed to read logs: %v", logErr)
+	}
 
 	return ExecutorResult{
 		Success:  success,
@@ -263,12 +267,15 @@ func (k *KubernetesExecutor) waitForCompletion(ctx context.Context, name string,
 }
 
 // readLogs finds the pod for the given job and reads the main container logs.
-func (k *KubernetesExecutor) readLogs(ctx context.Context, jobName string) (stdout string, stderr string) {
+func (k *KubernetesExecutor) readLogs(ctx context.Context, jobName string) (string, error) {
 	pods, err := k.client.CoreV1().Pods(k.namespace).List(ctx, metav1.ListOptions{
 		LabelSelector: fmt.Sprintf("job-name=%s", jobName),
 	})
-	if err != nil || len(pods.Items) == 0 {
-		return "", fmt.Sprintf("failed to list pods for job %s: %v", jobName, err)
+	if err != nil {
+		return "", fmt.Errorf("failed to list pods for job %s: %w", jobName, err)
+	}
+	if len(pods.Items) == 0 {
+		return "", fmt.Errorf("no pods found for job %s", jobName)
 	}
 
 	podName := pods.Items[0].Name
@@ -277,18 +284,21 @@ func (k *KubernetesExecutor) readLogs(ctx context.Context, jobName string) (stdo
 		Container: container,
 	})
 
-	stream, err := req.Stream(ctx)
+	logCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+
+	stream, err := req.Stream(logCtx)
 	if err != nil {
-		return "", fmt.Sprintf("failed to stream logs: %v", err)
+		return "", fmt.Errorf("failed to stream logs: %w", err)
 	}
 	defer stream.Close()
 
 	data, err := io.ReadAll(stream)
 	if err != nil {
-		return "", fmt.Sprintf("failed to read logs: %v", err)
+		return "", fmt.Errorf("failed to read logs: %w", err)
 	}
 
-	return string(data), ""
+	return string(data), nil
 }
 
 // Cleanup deletes the Kubernetes Job and its pods using background propagation.

--- a/internal/executor/kubernetes_test.go
+++ b/internal/executor/kubernetes_test.go
@@ -1,11 +1,20 @@
 package executor
 
 import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
 )
 
 func TestK8sJobSpec(t *testing.T) {
@@ -55,4 +64,107 @@ func TestK8sJobName(t *testing.T) {
 	k := &KubernetesExecutor{}
 	assert.Equal(t, "neuralforge-owner-repo-42", k.jobName("owner/repo#42"))
 	assert.Equal(t, "neuralforge-simple", k.jobName("simple"))
+}
+
+// testK8sWithServer creates a KubernetesExecutor backed by an httptest server.
+func testK8sWithServer(t *testing.T, handler http.Handler) *KubernetesExecutor {
+	t.Helper()
+	server := httptest.NewServer(handler)
+	t.Cleanup(server.Close)
+	client, err := kubernetes.NewForConfig(&rest.Config{Host: server.URL})
+	require.NoError(t, err)
+	return NewKubernetesWithClient(client, "test-ns", "test-image", "secret", "git-secret", "1", "1Gi")
+}
+
+// podListResponse returns a JSON-encoded PodList with the given pods.
+func podListResponse(w http.ResponseWriter, pods ...corev1.Pod) {
+	resp := corev1.PodList{
+		TypeMeta: metav1.TypeMeta{Kind: "PodList", APIVersion: "v1"},
+		Items:    pods,
+	}
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(resp)
+}
+
+func TestK8sReadLogs_PodListError(t *testing.T) {
+	k := testK8sWithServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusInternalServerError)
+		json.NewEncoder(w).Encode(metav1.Status{
+			TypeMeta: metav1.TypeMeta{Kind: "Status", APIVersion: "v1"},
+			Status:   "Failure",
+			Message:  "internal error",
+			Code:     500,
+		})
+	}))
+
+	stdout, err := k.readLogs(context.Background(), "test-job")
+	assert.Empty(t, stdout)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to list pods")
+}
+
+func TestK8sReadLogs_EmptyPodList(t *testing.T) {
+	k := testK8sWithServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		podListResponse(w) // empty list
+	}))
+
+	stdout, err := k.readLogs(context.Background(), "test-job")
+	assert.Empty(t, stdout)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "no pods found")
+}
+
+func TestK8sReadLogs_StreamError(t *testing.T) {
+	k := testK8sWithServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.Contains(r.URL.Path, "/log") {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusInternalServerError)
+			json.NewEncoder(w).Encode(metav1.Status{
+				TypeMeta: metav1.TypeMeta{Kind: "Status", APIVersion: "v1"},
+				Status:   "Failure",
+				Message:  "log stream error",
+				Code:     500,
+			})
+			return
+		}
+		podListResponse(w, corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-pod", Namespace: "test-ns"},
+		})
+	}))
+
+	stdout, err := k.readLogs(context.Background(), "test-job")
+	assert.Empty(t, stdout)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to stream logs")
+}
+
+func TestK8sReadLogs_Success(t *testing.T) {
+	k := testK8sWithServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.Contains(r.URL.Path, "/log") {
+			w.Header().Set("Content-Type", "text/plain")
+			w.Write([]byte("hello from the pod\n"))
+			return
+		}
+		podListResponse(w, corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-pod", Namespace: "test-ns"},
+		})
+	}))
+
+	stdout, err := k.readLogs(context.Background(), "test-job")
+	assert.NoError(t, err)
+	assert.Equal(t, "hello from the pod\n", stdout)
+}
+
+func TestK8sReadLogs_ContextCancelled(t *testing.T) {
+	k := testK8sWithServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Error("handler should not be called with cancelled context")
+	}))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // cancel immediately
+
+	stdout, err := k.readLogs(ctx, "test-job")
+	assert.Empty(t, stdout)
+	assert.Error(t, err)
 }


### PR DESCRIPTION
## Implementation for #13

**Issue:** MEDIUM: K8s log reading returns errors as strings

### Approved Plan
Now I have a complete picture. Here's the implementation plan:

---

### Approach

Change `readLogs()` to return a proper `error` instead of formatting errors into the `stderr` string. This lets `Run()` and its callers distinguish real log content from infrastructure errors. Additionally, add a context timeout to the log stream to prevent hanging on a stalled Kubernetes API connection.

### Files to Modify

1. **`internal/executor/kubernetes.go`** — Refactor `readLogs` signature and add stream timeout
2. **`internal/executor/kubernetes_test.go`** — Add tests for `readLogs` error propagation and timeout behavior

### Implementation Steps

1. **Change `readLogs` signature** (`kubernetes.go:266`)
   - Change from `(stdout string, stderr string)` to `(string, error)`
   - Replace the three `fmt.Sprintf` error returns (lines 271, 282, 288) with proper `fmt.Errorf` calls using `%w` wrapping, returning `("", err)`
   - On success (line 291), return `(string(data), nil)`

2. **Add stream timeout** (`kubernetes.go:280-286`)
   - Create a derived context with a 30-second timeout before calling `req.Stream(ctx)`: `logCtx, cancel := context.WithTimeout(ctx, 30*time.Second)` / `defer cancel()`
   - Use `logCtx` for `req.Stream()` and wrap `io.ReadAll` to respect the context (the stream already respects context cancellation from the K8s client)

3. **Update `Run()` to handle the new error return** (`kubernetes.go:225-232`)
   - Change `stdout, stderr := k.readLogs(ctx, name)` to `stdout, err := k.readLogs(ctx, name)`
   - If `err != nil`, populate `Stderr` with a descriptive message from the error and keep `Success` from the job status (log read failure shouldn't override the job success/fail status):
     ```go
     stdout, logErr := k.readLogs(ctx, name)
     var stderr string
     if logErr != nil {
         stderr = fmt.Sprintf("failed to read logs: %v", logErr)
     }
     ```
   - This preserves backward compatibility — `Stderr` still gets a string on failure, but the error

### Files Changed
- `internal/executor/kubernetes.go`
- `internal/executor/kubernetes_test.go`

### SAST Gate Warning
Auto-fix was attempted but some findings remain:
- [SECRET] `internal/executor/kubernetes.go` — unknown

Please review manually.

---
*Created by NeuralWarden Autopilot Issues Agent*