### PR TITLE
feat: implement #15 — MEDIUM: Job claim race condition in worker pool

### DIFF
--- a/internal/store/sqlite.go
+++ b/internal/store/sqlite.go
@@ -179,6 +179,31 @@ func (s *SQLiteStore) ListPendingJobs(limit int) ([]Job, error) {
 	return jobs, rows.Err()
 }
 
+func (s *SQLiteStore) ClaimPendingJobs(limit int) ([]Job, error) {
+	rows, err := s.db.Query(
+		`UPDATE jobs SET status = ?, current_stage = '', updated_at = ?
+		 WHERE id IN (
+			SELECT id FROM jobs WHERE status = ? ORDER BY created_at ASC LIMIT ?
+		 )
+		 RETURNING id, repo_full_name, issue_number, issue_title, status, current_stage, pipeline_state, error, cost_usd, created_at, updated_at, completed_at`,
+		JobRunning, time.Now().UTC(), JobQueued, limit,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("claim pending jobs: %w", err)
+	}
+	defer rows.Close()
+
+	var jobs []Job
+	for rows.Next() {
+		j, err := s.scanJob(rows)
+		if err != nil {
+			return nil, fmt.Errorf("scan claimed job: %w", err)
+		}
+		jobs = append(jobs, *j)
+	}
+	return jobs, rows.Err()
+}
+
 func (s *SQLiteStore) UpsertRepoContext(ctx RepoContextRecord) error {
 	langs, err := json.Marshal(ctx.Languages)
 	if err != nil {

--- a/internal/store/sqlite_test.go
+++ b/internal/store/sqlite_test.go
@@ -60,6 +60,30 @@ func TestListPendingJobs(t *testing.T) {
 	assert.Equal(t, "j1", jobs[0].ID)
 }
 
+func TestClaimPendingJobs(t *testing.T) {
+	s := newTestStore(t)
+	require.NoError(t, s.CreateJob(Job{ID: "j1", RepoFullName: "o/r", IssueNumber: 1, Status: JobQueued}))
+	require.NoError(t, s.CreateJob(Job{ID: "j2", RepoFullName: "o/r", IssueNumber: 2, Status: JobQueued}))
+	require.NoError(t, s.CreateJob(Job{ID: "j3", RepoFullName: "o/r", IssueNumber: 3, Status: JobRunning}))
+
+	// First claim should get the two queued jobs
+	jobs, err := s.ClaimPendingJobs(10)
+	require.NoError(t, err)
+	assert.Len(t, jobs, 2)
+	assert.Equal(t, JobRunning, jobs[0].Status)
+	assert.Equal(t, JobRunning, jobs[1].Status)
+
+	// Second claim should get nothing (already claimed)
+	jobs2, err := s.ClaimPendingJobs(10)
+	require.NoError(t, err)
+	assert.Len(t, jobs2, 0)
+
+	// Verify the jobs are now running in the database
+	got, err := s.GetJob("j1")
+	require.NoError(t, err)
+	assert.Equal(t, JobRunning, got.Status)
+}
+
 func TestCompleteJob(t *testing.T) {
 	s := newTestStore(t)
 	require.NoError(t, s.CreateJob(Job{ID: "j4", RepoFullName: "o/r", IssueNumber: 4, Status: JobRunning}))

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -43,6 +43,7 @@ type Store interface {
 	UpdateJobCost(id string, cost float64) error
 	CompleteJob(id string, status JobStatus) error
 	ListPendingJobs(limit int) ([]Job, error)
+	ClaimPendingJobs(limit int) ([]Job, error)
 	UpsertRepoContext(ctx RepoContextRecord) error
 	GetRepoContext(repoFullName string) (*RepoContextRecord, error)
 	Migrate() error

--- a/internal/worker/pool.go
+++ b/internal/worker/pool.go
@@ -59,16 +59,12 @@ func (p *Pool) poll(ctx context.Context) {
 		case <-ctx.Done():
 			return
 		case <-ticker.C:
-			jobs, err := p.store.ListPendingJobs(p.size)
+			jobs, err := p.store.ClaimPendingJobs(p.size)
 			if err != nil {
 				slog.Error("poll error", "error", err)
 				continue
 			}
 			for _, job := range jobs {
-				if err := p.store.UpdateJobStatus(job.ID, store.JobRunning, ""); err != nil {
-					slog.Error("update job status", "error", err)
-					continue
-				}
 				select {
 				case p.jobs <- job:
 				case <-ctx.Done():

--- a/internal/worker/pool_test.go
+++ b/internal/worker/pool_test.go
@@ -26,6 +26,17 @@ func (m *mockStore) ListPendingJobs(limit int) ([]store.Job, error) {
 	return []store.Job{j}, nil
 }
 
+func (m *mockStore) ClaimPendingJobs(limit int) ([]store.Job, error) {
+	if len(m.jobs) == 0 {
+		return nil, nil
+	}
+	j := m.jobs[0]
+	m.jobs = m.jobs[1:]
+	j.Status = store.JobRunning
+	atomic.AddInt32(&m.updated, 1)
+	return []store.Job{j}, nil
+}
+
 func (m *mockStore) UpdateJobStatus(id string, status store.JobStatus, stage string) error {
 	atomic.AddInt32(&m.updated, 1)
 	return nil


### PR DESCRIPTION
## Implementation for #15

**Issue:** MEDIUM: Job claim race condition in worker pool

### Approved Plan
Now I have a complete picture of the codebase. Here is the implementation plan:

---

### Approach

Replace the two-step list-then-update pattern in `pool.go:62-71` with a single atomic `ClaimPendingJobs` operation that uses an SQL `UPDATE ... WHERE status = 'queued' ... RETURNING` query. This atomically transitions jobs from `queued` to `running` in a single statement, eliminating the window where another poll cycle (or another process instance) could claim the same job.

### Files to Modify

1. **`internal/store/store.go`** — Add `ClaimPendingJobs(limit int) ([]Job, error)` to the `Store` interface.
2. **`internal/store/sqlite.go`** — Implement `ClaimPendingJobs` using an atomic `UPDATE ... RETURNING` query.
3. **`internal/worker/pool.go`** — Replace `ListPendingJobs` + `UpdateJobStatus` loop with a single `ClaimPendingJobs` call.
4. **`internal/store/sqlite_test.go`** — Add test for `ClaimPendingJobs` verifying atomicity.
5. **`internal/worker/pool_test.go`** — Update `mockStore` to implement `ClaimPendingJobs`.

### Implementation Steps

**Step 1: Add `ClaimPendingJobs` to the Store interface (`internal/store/store.go`)**

Add to the `Store` interface (after line 45):
```go
ClaimPendingJobs(limit int) ([]Job, error)
```

This method atomically selects pending jobs and transitions them to `running` in one operation, returning the claimed jobs.

**Step 2: Implement `ClaimPendingJobs` in SQLiteStore (`internal/store/sqlite.go`)**

Add a new method after `ListPendingJobs`:
```go
func (s *SQLiteStore) ClaimPendingJobs(limit int) ([]Job, error) {
	rows, err := s.db.Query(
		`UPDATE jobs SET status = ?, current_stage = '', updated_at = ?
		 WHERE id IN (
			SELECT id FROM jobs WHERE status = ? ORDER BY created_at ASC LIMIT ?
		 )
		 RETURNING id, repo_full_name, issue_number, issue_title, status, current_stage, pipeline_state, error, cost_usd, created_at, updated_at, completed_at`,
		JobRunning, time.Now().UTC(), JobQueued, limit,
	)
	if err != nil {
		return nil, fmt.

### Files Changed
- `internal/store/sqlite.go`
- `internal/store/sqlite_test.go`
- `internal/store/store.go`
- `internal/worker/pool.go`
- `internal/worker/pool_test.go`

---
*Created by NeuralWarden Autopilot Issues Agent*