### PR TITLE
feat: implement #6 — HIGH: Executor cleanup errors silently ignored

### DIFF
--- a/internal/executor/docker.go
+++ b/internal/executor/docker.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"log/slog"
 	"os/exec"
 	"strings"
 )
@@ -58,5 +59,10 @@ func (d *DockerExecutor) Run(ctx context.Context, job ExecutorJob) (ExecutorResu
 
 func (d *DockerExecutor) Cleanup(ctx context.Context, jobID string) error {
 	cmd := exec.CommandContext(ctx, "docker", "rm", "-f", fmt.Sprintf("nf-%s", jobID))
-	return cmd.Run()
+	if err := cmd.Run(); err != nil {
+		slog.Error("docker cleanup failed", "job_id", jobID, "error", err)
+		return fmt.Errorf("docker cleanup: %w", err)
+	}
+	slog.Info("docker cleanup completed", "job_id", jobID)
+	return nil
 }

--- a/internal/executor/docker_test.go
+++ b/internal/executor/docker_test.go
@@ -1,6 +1,7 @@
 package executor
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -22,4 +23,32 @@ func TestDockerJobArgs(t *testing.T) {
 	assert.Contains(t, args, "--rm")
 	assert.Contains(t, args, "ghcr.io/test:latest")
 	assert.Contains(t, args, "-w")
+}
+
+func TestDockerCleanup(t *testing.T) {
+	d := NewDocker("ghcr.io/test:latest")
+
+	tests := []struct {
+		name  string
+		jobID string
+	}{
+		{name: "nonexistent container", jobID: "nonexistent-job-123"},
+		{name: "empty job id", jobID: ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancel()
+
+			err := d.Cleanup(ctx, tt.jobID)
+			// docker may or may not be available in the test environment;
+			// either way we exercise the code path and verify it returns an error
+			// (docker not installed) or nil (docker present, container not found
+			// is not an error for "docker rm -f").
+			if err != nil {
+				assert.Contains(t, err.Error(), "docker cleanup")
+			}
+		})
+	}
 }

--- a/internal/executor/kubernetes.go
+++ b/internal/executor/kubernetes.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"log/slog"
 	"regexp"
 	"strings"
 	"time"
@@ -295,7 +296,12 @@ func (k *KubernetesExecutor) readLogs(ctx context.Context, jobName string) (stdo
 func (k *KubernetesExecutor) Cleanup(ctx context.Context, jobID string) error {
 	name := k.jobName(jobID)
 	propagation := metav1.DeletePropagationBackground
-	return k.client.BatchV1().Jobs(k.namespace).Delete(ctx, name, metav1.DeleteOptions{
+	if err := k.client.BatchV1().Jobs(k.namespace).Delete(ctx, name, metav1.DeleteOptions{
 		PropagationPolicy: &propagation,
-	})
+	}); err != nil {
+		slog.Error("kubernetes cleanup failed", "job_id", jobID, "job_name", name, "error", err)
+		return fmt.Errorf("kubernetes cleanup: %w", err)
+	}
+	slog.Info("kubernetes cleanup completed", "job_id", jobID, "job_name", name)
+	return nil
 }

--- a/internal/executor/kubernetes_test.go
+++ b/internal/executor/kubernetes_test.go
@@ -1,11 +1,15 @@
 package executor
 
 import (
+	"context"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	batchv1 "k8s.io/api/batch/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
 )
 
 func TestK8sJobSpec(t *testing.T) {
@@ -55,4 +59,36 @@ func TestK8sJobName(t *testing.T) {
 	k := &KubernetesExecutor{}
 	assert.Equal(t, "neuralforge-owner-repo-42", k.jobName("owner/repo#42"))
 	assert.Equal(t, "neuralforge-simple", k.jobName("simple"))
+}
+
+func TestK8sCleanup(t *testing.T) {
+	const namespace = "test-ns"
+
+	t.Run("cleanup existing job", func(t *testing.T) {
+		fakeClient := fake.NewSimpleClientset(&batchv1.Job{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "neuralforge-job-1",
+				Namespace: namespace,
+			},
+		})
+
+		k := NewKubernetesWithClient(fakeClient, namespace, "img:v1", "secret", "git-secret", "1", "1Gi")
+
+		err := k.Cleanup(context.Background(), "job-1")
+		require.NoError(t, err)
+
+		// Verify the job was actually deleted
+		jobs, err := fakeClient.BatchV1().Jobs(namespace).List(context.Background(), metav1.ListOptions{})
+		require.NoError(t, err)
+		assert.Empty(t, jobs.Items)
+	})
+
+	t.Run("cleanup nonexistent job returns error", func(t *testing.T) {
+		fakeClient := fake.NewSimpleClientset()
+		k := NewKubernetesWithClient(fakeClient, namespace, "img:v1", "secret", "git-secret", "1", "1Gi")
+
+		err := k.Cleanup(context.Background(), "nonexistent")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "kubernetes cleanup")
+	})
 }

--- a/internal/pipeline/execute.go
+++ b/internal/pipeline/execute.go
@@ -3,6 +3,7 @@ package pipeline
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"time"
 
 	"github.com/mandadapu/neuralforge/internal/executor"
@@ -30,6 +31,14 @@ func (s *ExecuteStage) Run(ctx context.Context, state *PipelineState) (StageResu
 		Context:  state.Memory,
 		Timeout:  s.timeout,
 	}
+
+	defer func() {
+		cleanupCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+		if err := s.exec.Cleanup(cleanupCtx, job.ID); err != nil {
+			slog.Error("executor cleanup failed", "job_id", job.ID, "executor", s.exec.Name(), "error", err)
+		}
+	}()
 
 	result, err := s.exec.Run(ctx, job)
 	if err != nil {


### PR DESCRIPTION
## Implementation for #6

**Issue:** HIGH: Executor cleanup errors silently ignored

### Approved Plan
Now I have a complete picture. Here's the implementation plan:

---

### Approach

The issue is twofold: (1) `Cleanup()` methods in both Docker and Kubernetes executors silently swallow errors — they return the error but no caller logs it, and (2) `ExecuteStage.Run()` never calls `Cleanup()` at all, meaning containers/pods are orphaned after every job. The fix adds structured logging (`log/slog`) inside each `Cleanup()` method and wires a deferred `Cleanup()` call into `ExecuteStage.Run()`.

### Files to Modify

1. **`internal/executor/docker.go`** — Add `log/slog` import; log errors and success in `Cleanup()`
2. **`internal/executor/kubernetes.go`** — Add `log/slog` import; log errors and success in `Cleanup()`
3. **`internal/pipeline/execute.go`** — Add deferred `Cleanup()` call after the job is built, with error logging
4. **`internal/executor/docker_test.go`** — Add test for `Cleanup()` error return
5. **`internal/executor/kubernetes_test.go`** — Add test for `Cleanup()` error return using fake K8s client

### Implementation Steps

**Step 1: `internal/executor/docker.go` — Log cleanup outcomes (lines 59-62)**

Add `"log/slog"` to imports. Replace the bare `return cmd.Run()` with:

```go
func (d *DockerExecutor) Cleanup(ctx context.Context, jobID string) error {
	cmd := exec.CommandContext(ctx, "docker", "rm", "-f", fmt.Sprintf("nf-%s", jobID))
	if err := cmd.Run(); err != nil {
		slog.Error("docker cleanup failed", "job_id", jobID, "error", err)
		return fmt.Errorf("docker cleanup: %w", err)
	}
	slog.Info("docker cleanup completed", "job_id", jobID)
	return nil
}
```

**Step 2: `internal/executor/kubernetes.go` — Log cleanup outcomes (lines 294-301)**

Add `"log/slog"` to imports. Replace the bare `return` with:

```go
func (k *KubernetesExecutor) Cleanup(ctx context.Context, jobID string) error {
	name := k.jobName(jobID)
	propagation := metav1.DeletePropagationBackground
	if err := k.client.BatchV1().Jobs(k.namespace).Delete(ctx, name, metav1.DeleteOptions{
		

### Files Changed
- `internal/executor/docker.go`
- `internal/executor/docker_test.go`
- `internal/executor/kubernetes.go`
- `internal/executor/kubernetes_test.go`
- `internal/pipeline/execute.go`
- `run_tests.sh`

### SAST Gate Warning
Auto-fix was attempted but some findings remain:
- [SECRET] `internal/executor/kubernetes.go` — unknown

Please review manually.

---
*Created by NeuralWarden Autopilot Issues Agent*