### PR TITLE
feat: implement #3 — CRITICAL: Shell injection in K8s executor pod script

### DIFF
--- a/internal/executor/kubernetes.go
+++ b/internal/executor/kubernetes.go
@@ -19,6 +19,25 @@ import (
 )
 
 var nonAlphanumeric = regexp.MustCompile(`[^a-z0-9]+`)
+var validBranch = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9/_.\-]*$`)
+var validRepoPath = regexp.MustCompile(`^[a-zA-Z0-9._-]+/[a-zA-Z0-9._-]+$`)
+
+func validateBranch(branch string) error {
+	if len(branch) == 0 || len(branch) > 255 {
+		return fmt.Errorf("branch name invalid length: %d", len(branch))
+	}
+	if !validBranch.MatchString(branch) {
+		return fmt.Errorf("branch name contains invalid characters: %s", branch)
+	}
+	return nil
+}
+
+func validateRepoPath(path string) error {
+	if !validRepoPath.MatchString(path) {
+		return fmt.Errorf("repo path must be owner/repo format: %s", path)
+	}
+	return nil
+}
 
 // KubernetesExecutor runs jobs as Kubernetes Jobs using client-go.
 type KubernetesExecutor struct {
@@ -89,6 +108,18 @@ func (k *KubernetesExecutor) jobName(id string) string {
 	return name
 }
 
+// promptConfigMapName derives a DNS-safe ConfigMap name from a job ID.
+func (k *KubernetesExecutor) promptConfigMapName(id string) string {
+	name := "neuralforge-prompt-" + strings.ToLower(id)
+	name = nonAlphanumeric.ReplaceAllString(name, "-")
+	name = strings.Trim(name, "-")
+	if len(name) > 63 {
+		name = name[:63]
+		name = strings.TrimRight(name, "-")
+	}
+	return name
+}
+
 // buildJobSpec constructs the Kubernetes Job spec for the given ExecutorJob.
 func (k *KubernetesExecutor) buildJobSpec(job ExecutorJob) *batchv1.Job {
 	backoffLimit := int32(0)
@@ -96,17 +127,19 @@ func (k *KubernetesExecutor) buildJobSpec(job ExecutorJob) *batchv1.Job {
 
 	// Shell script for the main container: configure git, create branch,
 	// run claude, commit and push if changes exist.
-	script := fmt.Sprintf(`set -e
+	// All user-controlled values are passed via env vars or ConfigMap volume
+	// to prevent shell injection.
+	script := `set -e
 git config user.email "neuralforge@bot"
 git config user.name "NeuralForge"
-git checkout -b %s
-claude -p %q --dangerously-skip-permissions
+git checkout -b "$BRANCH"
+claude -p "$(cat /etc/neuralforge/prompt)" --dangerously-skip-permissions
 if [ -n "$(git status --porcelain)" ]; then
   git add -A
   git commit -m "neuralforge: apply changes"
-  git push origin %s
+  git push origin "$BRANCH"
 fi
-`, job.Branch, job.Prompt, job.Branch)
+`
 
 	return &batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{
@@ -125,12 +158,9 @@ fi
 					RestartPolicy: corev1.RestartPolicyNever,
 					InitContainers: []corev1.Container{
 						{
-							Name:  "git-clone",
-							Image: "alpine/git",
-							Command: []string{"sh", "-c", fmt.Sprintf(
-								`git clone https://x-access-token:$(GIT_TOKEN)@github.com/%s.git /workspace`,
-								job.RepoPath,
-							)},
+							Name:    "git-clone",
+							Image:   "alpine/git",
+							Command: []string{"sh", "-c", `git clone "https://x-access-token:${GIT_TOKEN}@github.com/${REPO_PATH}.git" /workspace`},
 							Env: []corev1.EnvVar{
 								{
 									Name: "GIT_TOKEN",
@@ -142,6 +172,10 @@ fi
 											Key: "token",
 										},
 									},
+								},
+								{
+									Name:  "REPO_PATH",
+									Value: job.RepoPath,
 								},
 							},
 							VolumeMounts: []corev1.VolumeMount{
@@ -176,6 +210,10 @@ fi
 										},
 									},
 								},
+								{
+									Name:  "BRANCH",
+									Value: job.Branch,
+								},
 							},
 							Resources: corev1.ResourceRequirements{
 								Requests: corev1.ResourceList{
@@ -189,6 +227,7 @@ fi
 							},
 							VolumeMounts: []corev1.VolumeMount{
 								{Name: "workspace", MountPath: "/workspace"},
+								{Name: "prompt", MountPath: "/etc/neuralforge", ReadOnly: true},
 							},
 						},
 					},
@@ -197,6 +236,16 @@ fi
 							Name: "workspace",
 							VolumeSource: corev1.VolumeSource{
 								EmptyDir: &corev1.EmptyDirVolumeSource{},
+							},
+						},
+						{
+							Name: "prompt",
+							VolumeSource: corev1.VolumeSource{
+								ConfigMap: &corev1.ConfigMapVolumeSource{
+									LocalObjectReference: corev1.LocalObjectReference{
+										Name: k.promptConfigMapName(job.ID),
+									},
+								},
 							},
 						},
 					},
@@ -209,6 +258,26 @@ fi
 // Run creates a Kubernetes Job, waits for completion, reads logs, and returns
 // the result.
 func (k *KubernetesExecutor) Run(ctx context.Context, job ExecutorJob) (ExecutorResult, error) {
+	if err := validateBranch(job.Branch); err != nil {
+		return ExecutorResult{}, fmt.Errorf("invalid branch: %w", err)
+	}
+	if err := validateRepoPath(job.RepoPath); err != nil {
+		return ExecutorResult{}, fmt.Errorf("invalid repo path: %w", err)
+	}
+
+	// Create ConfigMap with prompt content
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      k.promptConfigMapName(job.ID),
+			Namespace: k.namespace,
+			Labels:    map[string]string{"app": "neuralforge", "job-id": job.ID},
+		},
+		Data: map[string]string{"prompt": job.Prompt},
+	}
+	if _, err := k.client.CoreV1().ConfigMaps(k.namespace).Create(ctx, cm, metav1.CreateOptions{}); err != nil {
+		return ExecutorResult{}, fmt.Errorf("failed to create prompt configmap: %w", err)
+	}
+
 	k8sJob := k.buildJobSpec(job)
 
 	created, err := k.client.BatchV1().Jobs(k.namespace).Create(ctx, k8sJob, metav1.CreateOptions{})
@@ -291,11 +360,20 @@ func (k *KubernetesExecutor) readLogs(ctx context.Context, jobName string) (stdo
 	return string(data), ""
 }
 
-// Cleanup deletes the Kubernetes Job and its pods using background propagation.
+// Cleanup deletes the Kubernetes Job, its pods, and the prompt ConfigMap.
 func (k *KubernetesExecutor) Cleanup(ctx context.Context, jobID string) error {
 	name := k.jobName(jobID)
 	propagation := metav1.DeletePropagationBackground
-	return k.client.BatchV1().Jobs(k.namespace).Delete(ctx, name, metav1.DeleteOptions{
+	err := k.client.BatchV1().Jobs(k.namespace).Delete(ctx, name, metav1.DeleteOptions{
 		PropagationPolicy: &propagation,
 	})
+	// Best-effort cleanup of prompt ConfigMap
+	cmErr := k.client.CoreV1().ConfigMaps(k.namespace).Delete(ctx, k.promptConfigMapName(jobID), metav1.DeleteOptions{})
+	if err != nil {
+		return err
+	}
+	if cmErr != nil {
+		return fmt.Errorf("failed to delete prompt configmap: %w", cmErr)
+	}
+	return nil
 }

--- a/internal/executor/kubernetes_test.go
+++ b/internal/executor/kubernetes_test.go
@@ -1,6 +1,7 @@
 package executor
 
 import (
+	"strings"
 	"testing"
 	"time"
 
@@ -38,21 +39,198 @@ func TestK8sJobSpec(t *testing.T) {
 	require.NotNil(t, k8sJob.Spec.ActiveDeadlineSeconds)
 	assert.Equal(t, int64(1800), *k8sJob.Spec.ActiveDeadlineSeconds)
 
+	// Init container checks
 	require.Len(t, k8sJob.Spec.Template.Spec.InitContainers, 1)
-	assert.Equal(t, "git-clone", k8sJob.Spec.Template.Spec.InitContainers[0].Name)
+	initContainer := k8sJob.Spec.Template.Spec.InitContainers[0]
+	assert.Equal(t, "git-clone", initContainer.Name)
 
+	// Init container should use env var for REPO_PATH, not interpolation
+	initCmd := strings.Join(initContainer.Command, " ")
+	assert.NotContains(t, initCmd, "owner/repo", "init container command should not contain interpolated repo path")
+	assert.Contains(t, initCmd, "${REPO_PATH}", "init container should reference REPO_PATH env var")
+
+	// Verify REPO_PATH env var is set on init container
+	var foundRepoPath bool
+	for _, env := range initContainer.Env {
+		if env.Name == "REPO_PATH" {
+			foundRepoPath = true
+			assert.Equal(t, "owner/repo", env.Value)
+		}
+	}
+	assert.True(t, foundRepoPath, "init container should have REPO_PATH env var")
+
+	// Main container checks
 	require.Len(t, k8sJob.Spec.Template.Spec.Containers, 1)
 	main := k8sJob.Spec.Template.Spec.Containers[0]
 	assert.Equal(t, "claude-executor", main.Name)
 	assert.Equal(t, "claude-exec:v1", main.Image)
 	assert.Equal(t, "/workspace", main.WorkingDir)
 
-	require.Len(t, k8sJob.Spec.Template.Spec.Volumes, 1)
+	// Main container script should use env vars, not interpolated values
+	mainCmd := strings.Join(main.Command, " ")
+	assert.NotContains(t, mainCmd, "neuralforge/issue-42", "main container command should not contain interpolated branch")
+	assert.NotContains(t, mainCmd, "Fix the login bug", "main container command should not contain interpolated prompt")
+	assert.Contains(t, mainCmd, "$BRANCH", "main container should reference BRANCH env var")
+	assert.Contains(t, mainCmd, "/etc/neuralforge/prompt", "main container should read prompt from ConfigMap mount")
+
+	// Verify BRANCH env var is set on main container
+	var foundBranch bool
+	for _, env := range main.Env {
+		if env.Name == "BRANCH" {
+			foundBranch = true
+			assert.Equal(t, "neuralforge/issue-42", env.Value)
+		}
+	}
+	assert.True(t, foundBranch, "main container should have BRANCH env var")
+
+	// Volume mount checks
+	require.Len(t, main.VolumeMounts, 2)
+	assert.Equal(t, "workspace", main.VolumeMounts[0].Name)
+	assert.Equal(t, "prompt", main.VolumeMounts[1].Name)
+	assert.Equal(t, "/etc/neuralforge", main.VolumeMounts[1].MountPath)
+	assert.True(t, main.VolumeMounts[1].ReadOnly)
+
+	// Volume checks
+	require.Len(t, k8sJob.Spec.Template.Spec.Volumes, 2)
 	assert.Equal(t, "workspace", k8sJob.Spec.Template.Spec.Volumes[0].Name)
+	assert.Equal(t, "prompt", k8sJob.Spec.Template.Spec.Volumes[1].Name)
+	require.NotNil(t, k8sJob.Spec.Template.Spec.Volumes[1].ConfigMap)
+	assert.Equal(t, k.promptConfigMapName("job-42"), k8sJob.Spec.Template.Spec.Volumes[1].ConfigMap.Name)
 }
 
 func TestK8sJobName(t *testing.T) {
 	k := &KubernetesExecutor{}
 	assert.Equal(t, "neuralforge-owner-repo-42", k.jobName("owner/repo#42"))
 	assert.Equal(t, "neuralforge-simple", k.jobName("simple"))
+}
+
+func TestK8sValidateBranch(t *testing.T) {
+	tests := []struct {
+		name    string
+		branch  string
+		wantErr bool
+	}{
+		{name: "valid simple", branch: "main", wantErr: false},
+		{name: "valid with slash", branch: "neuralforge/issue-42", wantErr: false},
+		{name: "valid with dot", branch: "fix/my-branch.v2", wantErr: false},
+		{name: "valid with underscore", branch: "feature/my_branch", wantErr: false},
+		{name: "injection semicolon", branch: "; rm -rf /", wantErr: true},
+		{name: "injection command sub", branch: "$(malicious)", wantErr: true},
+		{name: "injection backtick", branch: "`whoami`", wantErr: true},
+		{name: "empty string", branch: "", wantErr: true},
+		{name: "spaces", branch: "has space", wantErr: true},
+		{name: "newline", branch: "branch\nname", wantErr: true},
+		{name: "pipe", branch: "branch|cat", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateBranch(tt.branch)
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestK8sValidateRepoPath(t *testing.T) {
+	tests := []struct {
+		name    string
+		path    string
+		wantErr bool
+	}{
+		{name: "valid", path: "owner/repo", wantErr: false},
+		{name: "valid with dot", path: "my-org/my-repo.go", wantErr: false},
+		{name: "valid with dash", path: "my-org/my-repo", wantErr: false},
+		{name: "injection semicolon", path: "owner/repo; echo pwned", wantErr: true},
+		{name: "path traversal", path: "../../etc/passwd", wantErr: true},
+		{name: "empty string", path: "", wantErr: true},
+		{name: "no slash", path: "noslash", wantErr: true},
+		{name: "triple path", path: "a/b/c", wantErr: true},
+		{name: "backtick", path: "owner/`whoami`", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateRepoPath(tt.path)
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestK8sJobSpecNoInjection(t *testing.T) {
+	k := &KubernetesExecutor{
+		namespace:     "forge-ns",
+		image:         "claude-exec:v1",
+		secretName:    "llm-keys",
+		gitSecretName: "git-token",
+		cpu:           "2",
+		memory:        "4Gi",
+	}
+
+	// Use malicious values — buildJobSpec itself doesn't validate,
+	// but the script should never contain these as literal shell code.
+	job := ExecutorJob{
+		ID:       "job-evil",
+		RepoPath: "owner/repo",
+		Branch:   "$(whoami)",
+		Prompt:   `"; rm -rf / #`,
+		Context:  "",
+		Timeout:  10 * time.Minute,
+	}
+
+	k8sJob := k.buildJobSpec(job)
+
+	// The shell script in the main container must NOT contain the malicious values inline
+	mainCmd := strings.Join(k8sJob.Spec.Template.Spec.Containers[0].Command, " ")
+	assert.NotContains(t, mainCmd, "$(whoami)", "branch injection must not appear in shell script")
+	assert.NotContains(t, mainCmd, "rm -rf", "prompt injection must not appear in shell script")
+
+	// The init container command must NOT contain interpolated repo path
+	initCmd := strings.Join(k8sJob.Spec.Template.Spec.InitContainers[0].Command, " ")
+	assert.NotContains(t, initCmd, "owner/repo", "repo path must not be interpolated in init container command")
+
+	// Values should be in env vars instead
+	var branchEnv string
+	for _, env := range k8sJob.Spec.Template.Spec.Containers[0].Env {
+		if env.Name == "BRANCH" {
+			branchEnv = env.Value
+		}
+	}
+	assert.Equal(t, "$(whoami)", branchEnv, "malicious branch should be safely stored in env var")
+
+	var repoPathEnv string
+	for _, env := range k8sJob.Spec.Template.Spec.InitContainers[0].Env {
+		if env.Name == "REPO_PATH" {
+			repoPathEnv = env.Value
+		}
+	}
+	assert.Equal(t, "owner/repo", repoPathEnv, "repo path should be in env var")
+}
+
+func TestK8sPromptConfigMapName(t *testing.T) {
+	k := &KubernetesExecutor{}
+
+	// Deterministic
+	assert.Equal(t, k.promptConfigMapName("job-42"), k.promptConfigMapName("job-42"))
+
+	// DNS-safe: lowercase, no special chars
+	name := k.promptConfigMapName("Owner/Repo#42")
+	assert.Equal(t, name, strings.ToLower(name), "ConfigMap name should be lowercase")
+	assert.NotContains(t, name, "/", "ConfigMap name should not contain /")
+	assert.NotContains(t, name, "#", "ConfigMap name should not contain #")
+
+	// Max 63 chars
+	longID := strings.Repeat("a", 100)
+	longName := k.promptConfigMapName(longID)
+	assert.LessOrEqual(t, len(longName), 63, "ConfigMap name must not exceed 63 chars")
+
+	// Prefix
+	assert.True(t, strings.HasPrefix(k.promptConfigMapName("test-id"), "neuralforge-prompt-"))
 }


### PR DESCRIPTION
## Implementation for #3

**Issue:** CRITICAL: Shell injection in K8s executor pod script

### Approved Plan
Here is the implementation plan:

---

### Approach

The `buildJobSpec()` function has three shell injection vectors: `job.Branch` (unquoted `%s`), `job.Prompt` (Go `%q` is not shell-safe), and `job.RepoPath` (unquoted in init container). The fix uses a defense-in-depth strategy: (1) strict input validation to reject malicious values early, (2) environment variables instead of string interpolation for all user-controlled values in shell scripts, and (3) a ConfigMap volume mount for the prompt (which can be arbitrarily large and complex). The git token is already passed via K8s Secret env var, but the init container embeds it in a `fmt.Sprintf` command string alongside `RepoPath` — we fix this by moving `RepoPath` to an env var too.

### Files to Modify

1. **`internal/executor/kubernetes.go`** — Add validation functions, refactor `buildJobSpec()` to use env vars + ConfigMap, update `Run()` to create/cleanup ConfigMap, update `Cleanup()` to delete ConfigMap.
2. **`internal/executor/kubernetes_test.go`** — Update existing tests for new spec shape, add injection-attempt tests, add validation tests.

### Implementation Steps

**Step 1: Add input validation functions** (`kubernetes.go`)

Add two validation functions after the existing `nonAlphanumeric` regex:

```go
var validBranch = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9/_.\-]*$`)
var validRepoPath = regexp.MustCompile(`^[a-zA-Z0-9._-]+/[a-zA-Z0-9._-]+$`)

func validateBranch(branch string) error {
    if len(branch) == 0 || len(branch) > 255 {
        return fmt.Errorf("branch name invalid length: %d", len(branch))
    }
    if !validBranch.MatchString(branch) {
        return fmt.Errorf("branch name contains invalid characters: %s", branch)
    }
    return nil
}

func validateRepoPath(path string) error {
    if !validRepoPath.MatchString(path) {
        return fmt.Errorf("repo path must be owner/repo format: %s", path)
    }
    return nil
}
```

**Step 2: Refactor `buildJobSpec()` to eliminate string interpolat

### Files Changed
- `internal/executor/kubernetes.go`
- `internal/executor/kubernetes_test.go`

### SAST Gate Warning
Auto-fix was attempted but some findings remain:
- [SECRET] `internal/executor/kubernetes.go` — unknown

Please review manually.

---
*Created by NeuralWarden Autopilot Issues Agent*