### PR TITLE
feat: implement #1 — CRITICAL: Add context timeouts to all SQLite database operat

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -34,7 +34,7 @@ func New(cfg config.Config) (*App, error) {
 	if err != nil {
 		return nil, fmt.Errorf("open store: %w", err)
 	}
-	if err := s.Migrate(); err != nil {
+	if err := s.Migrate(context.Background()); err != nil {
 		s.Close()
 		return nil, fmt.Errorf("migrate store: %w", err)
 	}
@@ -125,7 +125,9 @@ func (a *App) handleEvent(eventType string, payload []byte) {
 			IssueTitle:   e.Issue.Title,
 			Status:       store.JobQueued,
 		}
-		if err := a.store.CreateJob(job); err != nil {
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		if err := a.store.CreateJob(ctx, job); err != nil {
 			slog.Error("create job", "error", err, "job_id", jobID)
 			return
 		}

--- a/internal/store/sqlite.go
+++ b/internal/store/sqlite.go
@@ -1,6 +1,7 @@
 package store
 
 import (
+	"context"
 	"database/sql"
 	"encoding/json"
 	"fmt"
@@ -8,6 +9,9 @@ import (
 
 	_ "modernc.org/sqlite"
 )
+
+// DefaultDBTimeout is the maximum time allowed for a single database operation.
+const DefaultDBTimeout = 5 * time.Second
 
 type SQLiteStore struct {
 	db *sql.DB
@@ -22,11 +26,17 @@ func NewSQLiteStore(dsn string) (*SQLiteStore, error) {
 		db.Close()
 		return nil, fmt.Errorf("set WAL mode: %w", err)
 	}
+	if _, err := db.Exec("PRAGMA busy_timeout = 5000"); err != nil {
+		db.Close()
+		return nil, fmt.Errorf("set busy timeout: %w", err)
+	}
 	return &SQLiteStore{db: db}, nil
 }
 
-func (s *SQLiteStore) Migrate() error {
-	_, err := s.db.Exec(`
+func (s *SQLiteStore) Migrate(ctx context.Context) error {
+	ctx, cancel := context.WithTimeout(ctx, DefaultDBTimeout)
+	defer cancel()
+	_, err := s.db.ExecContext(ctx, `
 		CREATE TABLE IF NOT EXISTS jobs (
 			id             TEXT PRIMARY KEY,
 			repo_full_name TEXT NOT NULL,
@@ -56,9 +66,11 @@ func (s *SQLiteStore) Migrate() error {
 	return nil
 }
 
-func (s *SQLiteStore) CreateJob(job Job) error {
+func (s *SQLiteStore) CreateJob(ctx context.Context, job Job) error {
+	ctx, cancel := context.WithTimeout(ctx, DefaultDBTimeout)
+	defer cancel()
 	now := time.Now().UTC()
-	_, err := s.db.Exec(
+	_, err := s.db.ExecContext(ctx,
 		`INSERT INTO jobs (id, repo_full_name, issue_number, issue_title, status, current_stage, pipeline_state, error, cost_usd, created_at, updated_at, completed_at)
 		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 		job.ID, job.RepoFullName, job.IssueNumber, job.IssueTitle,
@@ -88,8 +100,10 @@ func (s *SQLiteStore) scanJob(row interface{ Scan(...any) error }) (*Job, error)
 	return &j, nil
 }
 
-func (s *SQLiteStore) GetJob(id string) (*Job, error) {
-	row := s.db.QueryRow(
+func (s *SQLiteStore) GetJob(ctx context.Context, id string) (*Job, error) {
+	ctx, cancel := context.WithTimeout(ctx, DefaultDBTimeout)
+	defer cancel()
+	row := s.db.QueryRowContext(ctx,
 		`SELECT id, repo_full_name, issue_number, issue_title, status, current_stage, pipeline_state, error, cost_usd, created_at, updated_at, completed_at
 		 FROM jobs WHERE id = ?`, id,
 	)
@@ -100,8 +114,10 @@ func (s *SQLiteStore) GetJob(id string) (*Job, error) {
 	return j, nil
 }
 
-func (s *SQLiteStore) GetJobByIssue(repoFullName string, issueNumber int) (*Job, error) {
-	row := s.db.QueryRow(
+func (s *SQLiteStore) GetJobByIssue(ctx context.Context, repoFullName string, issueNumber int) (*Job, error) {
+	ctx, cancel := context.WithTimeout(ctx, DefaultDBTimeout)
+	defer cancel()
+	row := s.db.QueryRowContext(ctx,
 		`SELECT id, repo_full_name, issue_number, issue_title, status, current_stage, pipeline_state, error, cost_usd, created_at, updated_at, completed_at
 		 FROM jobs WHERE repo_full_name = ? AND issue_number = ?`, repoFullName, issueNumber,
 	)
@@ -112,8 +128,10 @@ func (s *SQLiteStore) GetJobByIssue(repoFullName string, issueNumber int) (*Job,
 	return j, nil
 }
 
-func (s *SQLiteStore) UpdateJobStatus(id string, status JobStatus, stage string) error {
-	_, err := s.db.Exec(
+func (s *SQLiteStore) UpdateJobStatus(ctx context.Context, id string, status JobStatus, stage string) error {
+	ctx, cancel := context.WithTimeout(ctx, DefaultDBTimeout)
+	defer cancel()
+	_, err := s.db.ExecContext(ctx,
 		`UPDATE jobs SET status = ?, current_stage = ?, updated_at = ? WHERE id = ?`,
 		status, stage, time.Now().UTC(), id,
 	)
@@ -123,8 +141,10 @@ func (s *SQLiteStore) UpdateJobStatus(id string, status JobStatus, stage string)
 	return nil
 }
 
-func (s *SQLiteStore) UpdateJobError(id string, errMsg string) error {
-	_, err := s.db.Exec(
+func (s *SQLiteStore) UpdateJobError(ctx context.Context, id string, errMsg string) error {
+	ctx, cancel := context.WithTimeout(ctx, DefaultDBTimeout)
+	defer cancel()
+	_, err := s.db.ExecContext(ctx,
 		`UPDATE jobs SET error = ?, status = ?, updated_at = ? WHERE id = ?`,
 		errMsg, JobFailed, time.Now().UTC(), id,
 	)
@@ -134,8 +154,10 @@ func (s *SQLiteStore) UpdateJobError(id string, errMsg string) error {
 	return nil
 }
 
-func (s *SQLiteStore) UpdateJobCost(id string, cost float64) error {
-	_, err := s.db.Exec(
+func (s *SQLiteStore) UpdateJobCost(ctx context.Context, id string, cost float64) error {
+	ctx, cancel := context.WithTimeout(ctx, DefaultDBTimeout)
+	defer cancel()
+	_, err := s.db.ExecContext(ctx,
 		`UPDATE jobs SET cost_usd = ?, updated_at = ? WHERE id = ?`,
 		cost, time.Now().UTC(), id,
 	)
@@ -145,9 +167,11 @@ func (s *SQLiteStore) UpdateJobCost(id string, cost float64) error {
 	return nil
 }
 
-func (s *SQLiteStore) CompleteJob(id string, status JobStatus) error {
+func (s *SQLiteStore) CompleteJob(ctx context.Context, id string, status JobStatus) error {
+	ctx, cancel := context.WithTimeout(ctx, DefaultDBTimeout)
+	defer cancel()
 	now := time.Now().UTC()
-	_, err := s.db.Exec(
+	_, err := s.db.ExecContext(ctx,
 		`UPDATE jobs SET status = ?, completed_at = ?, updated_at = ? WHERE id = ?`,
 		status, now, now, id,
 	)
@@ -157,8 +181,10 @@ func (s *SQLiteStore) CompleteJob(id string, status JobStatus) error {
 	return nil
 }
 
-func (s *SQLiteStore) ListPendingJobs(limit int) ([]Job, error) {
-	rows, err := s.db.Query(
+func (s *SQLiteStore) ListPendingJobs(ctx context.Context, limit int) ([]Job, error) {
+	ctx, cancel := context.WithTimeout(ctx, DefaultDBTimeout)
+	defer cancel()
+	rows, err := s.db.QueryContext(ctx,
 		`SELECT id, repo_full_name, issue_number, issue_title, status, current_stage, pipeline_state, error, cost_usd, created_at, updated_at, completed_at
 		 FROM jobs WHERE status = ? ORDER BY created_at ASC LIMIT ?`,
 		JobQueued, limit,
@@ -179,12 +205,14 @@ func (s *SQLiteStore) ListPendingJobs(limit int) ([]Job, error) {
 	return jobs, rows.Err()
 }
 
-func (s *SQLiteStore) UpsertRepoContext(ctx RepoContextRecord) error {
-	langs, err := json.Marshal(ctx.Languages)
+func (s *SQLiteStore) UpsertRepoContext(ctx context.Context, rc RepoContextRecord) error {
+	ctx, cancel := context.WithTimeout(ctx, DefaultDBTimeout)
+	defer cancel()
+	langs, err := json.Marshal(rc.Languages)
 	if err != nil {
 		return fmt.Errorf("marshal languages: %w", err)
 	}
-	_, err = s.db.Exec(
+	_, err = s.db.ExecContext(ctx,
 		`INSERT INTO repo_contexts (repo_full_name, claude_md_hash, last_analyzed_at, file_count, languages)
 		 VALUES (?, ?, ?, ?, ?)
 		 ON CONFLICT(repo_full_name) DO UPDATE SET
@@ -192,7 +220,7 @@ func (s *SQLiteStore) UpsertRepoContext(ctx RepoContextRecord) error {
 			last_analyzed_at = excluded.last_analyzed_at,
 			file_count = excluded.file_count,
 			languages = excluded.languages`,
-		ctx.RepoFullName, ctx.ClaudeMDHash, ctx.LastAnalyzedAt.UTC(), ctx.FileCount, string(langs),
+		rc.RepoFullName, rc.ClaudeMDHash, rc.LastAnalyzedAt.UTC(), rc.FileCount, string(langs),
 	)
 	if err != nil {
 		return fmt.Errorf("upsert repo context: %w", err)
@@ -200,10 +228,12 @@ func (s *SQLiteStore) UpsertRepoContext(ctx RepoContextRecord) error {
 	return nil
 }
 
-func (s *SQLiteStore) GetRepoContext(repoFullName string) (*RepoContextRecord, error) {
+func (s *SQLiteStore) GetRepoContext(ctx context.Context, repoFullName string) (*RepoContextRecord, error) {
+	ctx, cancel := context.WithTimeout(ctx, DefaultDBTimeout)
+	defer cancel()
 	var rc RepoContextRecord
 	var langsJSON string
-	err := s.db.QueryRow(
+	err := s.db.QueryRowContext(ctx,
 		`SELECT repo_full_name, claude_md_hash, last_analyzed_at, file_count, languages
 		 FROM repo_contexts WHERE repo_full_name = ?`, repoFullName,
 	).Scan(&rc.RepoFullName, &rc.ClaudeMDHash, &rc.LastAnalyzedAt, &rc.FileCount, &langsJSON)

--- a/internal/store/sqlite_test.go
+++ b/internal/store/sqlite_test.go
@@ -1,6 +1,7 @@
 package store
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -11,7 +12,7 @@ func newTestStore(t *testing.T) *SQLiteStore {
 	t.Helper()
 	s, err := NewSQLiteStore(":memory:")
 	require.NoError(t, err)
-	require.NoError(t, s.Migrate())
+	require.NoError(t, s.Migrate(context.Background()))
 	t.Cleanup(func() { s.Close() })
 	return s
 }
@@ -19,9 +20,9 @@ func newTestStore(t *testing.T) *SQLiteStore {
 func TestCreateAndGetJob(t *testing.T) {
 	s := newTestStore(t)
 	job := Job{ID: "job-1", RepoFullName: "owner/repo", IssueNumber: 42, IssueTitle: "Fix bug", Status: JobQueued}
-	require.NoError(t, s.CreateJob(job))
+	require.NoError(t, s.CreateJob(context.Background(), job))
 
-	got, err := s.GetJob("job-1")
+	got, err := s.GetJob(context.Background(), "job-1")
 	require.NoError(t, err)
 	assert.Equal(t, "owner/repo", got.RepoFullName)
 	assert.Equal(t, 42, got.IssueNumber)
@@ -30,19 +31,19 @@ func TestCreateAndGetJob(t *testing.T) {
 
 func TestGetJobByIssue(t *testing.T) {
 	s := newTestStore(t)
-	require.NoError(t, s.CreateJob(Job{ID: "job-2", RepoFullName: "owner/repo", IssueNumber: 7, Status: JobQueued}))
+	require.NoError(t, s.CreateJob(context.Background(), Job{ID: "job-2", RepoFullName: "owner/repo", IssueNumber: 7, Status: JobQueued}))
 
-	got, err := s.GetJobByIssue("owner/repo", 7)
+	got, err := s.GetJobByIssue(context.Background(), "owner/repo", 7)
 	require.NoError(t, err)
 	assert.Equal(t, "job-2", got.ID)
 }
 
 func TestUpdateJobStatus(t *testing.T) {
 	s := newTestStore(t)
-	require.NoError(t, s.CreateJob(Job{ID: "job-3", RepoFullName: "o/r", IssueNumber: 1, Status: JobQueued}))
-	require.NoError(t, s.UpdateJobStatus("job-3", JobRunning, "architect"))
+	require.NoError(t, s.CreateJob(context.Background(), Job{ID: "job-3", RepoFullName: "o/r", IssueNumber: 1, Status: JobQueued}))
+	require.NoError(t, s.UpdateJobStatus(context.Background(), "job-3", JobRunning, "architect"))
 
-	got, err := s.GetJob("job-3")
+	got, err := s.GetJob(context.Background(), "job-3")
 	require.NoError(t, err)
 	assert.Equal(t, JobRunning, got.Status)
 	assert.Equal(t, "architect", got.CurrentStage)
@@ -50,11 +51,11 @@ func TestUpdateJobStatus(t *testing.T) {
 
 func TestListPendingJobs(t *testing.T) {
 	s := newTestStore(t)
-	require.NoError(t, s.CreateJob(Job{ID: "j1", RepoFullName: "o/r", IssueNumber: 1, Status: JobQueued}))
-	require.NoError(t, s.CreateJob(Job{ID: "j2", RepoFullName: "o/r", IssueNumber: 2, Status: JobRunning}))
-	require.NoError(t, s.CreateJob(Job{ID: "j3", RepoFullName: "o/r", IssueNumber: 3, Status: JobCompleted}))
+	require.NoError(t, s.CreateJob(context.Background(), Job{ID: "j1", RepoFullName: "o/r", IssueNumber: 1, Status: JobQueued}))
+	require.NoError(t, s.CreateJob(context.Background(), Job{ID: "j2", RepoFullName: "o/r", IssueNumber: 2, Status: JobRunning}))
+	require.NoError(t, s.CreateJob(context.Background(), Job{ID: "j3", RepoFullName: "o/r", IssueNumber: 3, Status: JobCompleted}))
 
-	jobs, err := s.ListPendingJobs(10)
+	jobs, err := s.ListPendingJobs(context.Background(), 10)
 	require.NoError(t, err)
 	assert.Len(t, jobs, 1)
 	assert.Equal(t, "j1", jobs[0].ID)
@@ -62,11 +63,19 @@ func TestListPendingJobs(t *testing.T) {
 
 func TestCompleteJob(t *testing.T) {
 	s := newTestStore(t)
-	require.NoError(t, s.CreateJob(Job{ID: "j4", RepoFullName: "o/r", IssueNumber: 4, Status: JobRunning}))
-	require.NoError(t, s.CompleteJob("j4", JobCompleted))
+	require.NoError(t, s.CreateJob(context.Background(), Job{ID: "j4", RepoFullName: "o/r", IssueNumber: 4, Status: JobRunning}))
+	require.NoError(t, s.CompleteJob(context.Background(), "j4", JobCompleted))
 
-	got, err := s.GetJob("j4")
+	got, err := s.GetJob(context.Background(), "j4")
 	require.NoError(t, err)
 	assert.Equal(t, JobCompleted, got.Status)
 	assert.NotNil(t, got.CompletedAt)
+}
+
+func TestContextCancellation(t *testing.T) {
+	s := newTestStore(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // cancel immediately
+	err := s.CreateJob(ctx, Job{ID: "x", RepoFullName: "o/r", IssueNumber: 1, Status: JobQueued})
+	assert.Error(t, err)
 }

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -1,6 +1,9 @@
 package store
 
-import "time"
+import (
+	"context"
+	"time"
+)
 
 type JobStatus string
 
@@ -35,16 +38,16 @@ type RepoContextRecord struct {
 }
 
 type Store interface {
-	CreateJob(job Job) error
-	GetJob(id string) (*Job, error)
-	GetJobByIssue(repoFullName string, issueNumber int) (*Job, error)
-	UpdateJobStatus(id string, status JobStatus, stage string) error
-	UpdateJobError(id string, errMsg string) error
-	UpdateJobCost(id string, cost float64) error
-	CompleteJob(id string, status JobStatus) error
-	ListPendingJobs(limit int) ([]Job, error)
-	UpsertRepoContext(ctx RepoContextRecord) error
-	GetRepoContext(repoFullName string) (*RepoContextRecord, error)
-	Migrate() error
+	CreateJob(ctx context.Context, job Job) error
+	GetJob(ctx context.Context, id string) (*Job, error)
+	GetJobByIssue(ctx context.Context, repoFullName string, issueNumber int) (*Job, error)
+	UpdateJobStatus(ctx context.Context, id string, status JobStatus, stage string) error
+	UpdateJobError(ctx context.Context, id string, errMsg string) error
+	UpdateJobCost(ctx context.Context, id string, cost float64) error
+	CompleteJob(ctx context.Context, id string, status JobStatus) error
+	ListPendingJobs(ctx context.Context, limit int) ([]Job, error)
+	UpsertRepoContext(ctx context.Context, rc RepoContextRecord) error
+	GetRepoContext(ctx context.Context, repoFullName string) (*RepoContextRecord, error)
+	Migrate(ctx context.Context) error
 	Close() error
 }

--- a/internal/worker/pool.go
+++ b/internal/worker/pool.go
@@ -59,13 +59,13 @@ func (p *Pool) poll(ctx context.Context) {
 		case <-ctx.Done():
 			return
 		case <-ticker.C:
-			jobs, err := p.store.ListPendingJobs(p.size)
+			jobs, err := p.store.ListPendingJobs(ctx, p.size)
 			if err != nil {
 				slog.Error("poll error", "error", err)
 				continue
 			}
 			for _, job := range jobs {
-				if err := p.store.UpdateJobStatus(job.ID, store.JobRunning, ""); err != nil {
+				if err := p.store.UpdateJobStatus(ctx, job.ID, store.JobRunning, ""); err != nil {
 					slog.Error("update job status", "error", err)
 					continue
 				}

--- a/internal/worker/pool_test.go
+++ b/internal/worker/pool_test.go
@@ -17,7 +17,7 @@ type mockStore struct {
 	updated int32
 }
 
-func (m *mockStore) ListPendingJobs(limit int) ([]store.Job, error) {
+func (m *mockStore) ListPendingJobs(ctx context.Context, limit int) ([]store.Job, error) {
 	if len(m.jobs) == 0 {
 		return nil, nil
 	}
@@ -26,16 +26,16 @@ func (m *mockStore) ListPendingJobs(limit int) ([]store.Job, error) {
 	return []store.Job{j}, nil
 }
 
-func (m *mockStore) UpdateJobStatus(id string, status store.JobStatus, stage string) error {
+func (m *mockStore) UpdateJobStatus(ctx context.Context, id string, status store.JobStatus, stage string) error {
 	atomic.AddInt32(&m.updated, 1)
 	return nil
 }
 
-func (m *mockStore) CompleteJob(id string, status store.JobStatus) error {
+func (m *mockStore) CompleteJob(ctx context.Context, id string, status store.JobStatus) error {
 	return nil
 }
 
-func (m *mockStore) UpdateJobError(id string, errMsg string) error {
+func (m *mockStore) UpdateJobError(ctx context.Context, id string, errMsg string) error {
 	return nil
 }
 

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -25,11 +25,11 @@ func (w *Worker) Run(ctx context.Context, jobs <-chan store.Job) {
 
 		if err := w.handler(ctx, job); err != nil {
 			slog.Error("job failed", "worker", w.id, "job", job.ID, "error", err)
-			_ = w.store.UpdateJobError(job.ID, err.Error())
+			_ = w.store.UpdateJobError(ctx, job.ID, err.Error())
 			continue
 		}
 
-		_ = w.store.CompleteJob(job.ID, store.JobCompleted)
+		_ = w.store.CompleteJob(ctx, job.ID, store.JobCompleted)
 		slog.Info("job completed", "worker", w.id, "job", job.ID)
 	}
 }


### PR DESCRIPTION
## Implementation for #1

**Issue:** CRITICAL: Add context timeouts to all SQLite database operations

### Approved Plan
I now have a complete understanding of the codebase. Here is the implementation plan:

---

### Approach

Add `context.Context` as the first parameter to all `Store` interface methods (except `Close()`), and use `context.WithTimeout` inside each `SQLiteStore` method to wrap database calls. This ensures every SQL operation has a bounded execution time, preventing workers from hanging indefinitely on database locks or I/O stalls.

The `database/sql` package already supports context-aware variants: `ExecContext`, `QueryContext`, and `QueryRowContext`. The implementation swaps every `Exec`/`Query`/`QueryRow` call to its `*Context` counterpart, deriving a child context with a 5-second timeout from the caller-provided context.

A package-level `DefaultDBTimeout` constant will be introduced for the timeout duration, keeping it configurable in the future.

### Files to Modify

1. **`internal/store/store.go`** — Update the `Store` interface to accept `context.Context`
2. **`internal/store/sqlite.go`** — Implement context-aware methods using `ExecContext`/`QueryContext`/`QueryRowContext` with timeouts
3. **`internal/store/sqlite_test.go`** — Update tests to pass `context.Background()` or `context.TODO()`
4. **`internal/worker/pool.go`** — Pass `ctx` to store method calls
5. **`internal/worker/worker.go`** — Pass `ctx` to store method calls
6. **`internal/app/app.go`** — Pass `context.Background()` or request-scoped context to store calls in `handleEvent` and `New`
7. **`internal/worker/pool_test.go`** — Update mock store methods to accept `context.Context`

### Implementation Steps

**Step 1: Update `internal/store/store.go`**

Add `"context"` import. Update every interface method (except `Close()`) to take `ctx context.Context` as the first parameter:

```go
type Store interface {
	CreateJob(ctx context.Context, job Job) error
	GetJob(ctx context.Context, id string) (*Job, error)
	GetJobByIssue(ctx context.Context, repoFullName string, issueNumber int) (*Job, error)
	UpdateJ

### Files Changed
- `internal/app/app.go`
- `internal/store/sqlite.go`
- `internal/store/sqlite_test.go`
- `internal/store/store.go`
- `internal/worker/pool.go`
- `internal/worker/pool_test.go`
- `internal/worker/worker.go`

---
*Created by NeuralWarden Autopilot Issues Agent*