### PR TITLE
feat: implement #4 — HIGH: DB connection leak on migration failure

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -34,8 +34,14 @@ func New(cfg config.Config) (*App, error) {
 	if err != nil {
 		return nil, fmt.Errorf("open store: %w", err)
 	}
+	success := false
+	defer func() {
+		if !success {
+			s.Close()
+		}
+	}()
+
 	if err := s.Migrate(); err != nil {
-		s.Close()
 		return nil, fmt.Errorf("migrate store: %w", err)
 	}
 
@@ -59,6 +65,7 @@ func New(cfg config.Config) (*App, error) {
 		Handler: mux,
 	}
 
+	success = true
 	return a, nil
 }
 


### PR DESCRIPTION
## Implementation for #4

**Issue:** HIGH: DB connection leak on migration failure

### Approved Plan
I now have a complete picture. Here is the implementation plan:

---

### Approach

Replace the explicit `s.Close()` call on the migration error path with a `defer`-based cleanup pattern. This uses a `success` boolean flag: defer a closure that closes the store unless `success` is set to `true` before the final return. This ensures the DB connection is cleaned up on **any** error path in `New()`, including future ones, without requiring manual `Close()` calls at each exit point.

### Files to Modify

1. `internal/app/app.go` — lines 32–62 (the `New` function)

### Implementation Steps

1. **In `internal/app/app.go`, refactor the `New` function (lines 32–62):**

   After `store.NewSQLiteStore` succeeds (line 33), add a `success` flag and a deferred cleanup:

   ```go
   func New(cfg config.Config) (*App, error) {
       s, err := store.NewSQLiteStore(cfg.Store.DSN)
       if err != nil {
           return nil, fmt.Errorf("open store: %w", err)
       }
       success := false
       defer func() {
           if !success {
               s.Close()
           }
       }()

       if err := s.Migrate(); err != nil {
           return nil, fmt.Errorf("migrate store: %w", err)
       }

       // ... rest of function unchanged ...

       success = true
       return a, nil
   }
   ```

   Key changes:
   - Remove the explicit `s.Close()` call on line 38
   - Add `success := false` after store creation
   - Add `defer func() { if !success { s.Close() } }()` 
   - Add `success = true` immediately before the final `return a, nil` on line 62

### Testing

1. **Existing tests pass:** Run `make test` to confirm no regressions. The existing `webhook_test.go` tests don't exercise `New()` directly, but the full test suite should still pass.

2. **Manual verification:** The logic is straightforward — the `defer` fires on all return paths. On success (`return a, nil`), `success` is `true` so `Close()` is skipped. On any error return, `success` remains `false` so `Close()` runs. Thi

### Files Changed
- `internal/app/app.go`

---
*Created by NeuralWarden Autopilot Issues Agent*