### PR TITLE
feat: implement #11 — MEDIUM: No configuration validation

### DIFF
--- a/cmd/neuralforge/main.go
+++ b/cmd/neuralforge/main.go
@@ -35,6 +35,9 @@ func serveCmd() *cobra.Command {
 		Short: "Start the webhook server and worker pool",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cfg := config.LoadFromEnv()
+			if err := cfg.Validate(); err != nil {
+				return fmt.Errorf("configuration error: %w", err)
+			}
 
 			a, err := app.New(cfg)
 			if err != nil {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,8 +1,11 @@
 package config
 
 import (
+	"errors"
+	"fmt"
 	"os"
 	"strconv"
+	"strings"
 	"time"
 )
 
@@ -121,6 +124,86 @@ func LoadFromEnv() Config {
 			CommitToRepo:  envBool("NEURALFORGE_CONTEXT_COMMIT", true),
 		},
 	}
+}
+
+func (c Config) Validate() error {
+	var errs []string
+
+	// Server
+	if c.Server.Port < 1 || c.Server.Port > 65535 {
+		errs = append(errs, fmt.Sprintf("invalid server port: %d (must be 1-65535)", c.Server.Port))
+	}
+
+	// Workers
+	if c.Workers < 1 {
+		errs = append(errs, fmt.Sprintf("invalid workers: %d (must be >= 1)", c.Workers))
+	}
+
+	// GitHub — required for core functionality
+	if c.GitHub.AppID == 0 {
+		errs = append(errs, "GITHUB_APP_ID is required")
+	}
+	if c.GitHub.PrivateKeyPath == "" {
+		errs = append(errs, "GITHUB_PRIVATE_KEY_PATH is required")
+	}
+	if c.GitHub.WebhookSecret == "" {
+		errs = append(errs, "GITHUB_WEBHOOK_SECRET is required")
+	}
+
+	// LLM — validate the selected provider has an API key
+	switch c.LLM.DefaultProvider {
+	case "claude":
+		if c.LLM.Claude.APIKey == "" {
+			errs = append(errs, "ANTHROPIC_API_KEY is required when provider is claude")
+		}
+	case "openai":
+		if c.LLM.OpenAI.APIKey == "" {
+			errs = append(errs, "OPENAI_API_KEY is required when provider is openai")
+		}
+	default:
+		errs = append(errs, fmt.Sprintf("unknown LLM provider: %q (must be claude or openai)", c.LLM.DefaultProvider))
+	}
+
+	// Executor
+	switch c.Executor.DefaultType {
+	case "docker":
+		if c.Executor.Docker.Timeout <= 0 {
+			errs = append(errs, "docker timeout must be > 0")
+		}
+		if c.Executor.Docker.Image == "" {
+			errs = append(errs, "docker image is required")
+		}
+	case "kubernetes":
+		if c.Executor.Kubernetes.Timeout <= 0 {
+			errs = append(errs, "kubernetes timeout must be > 0")
+		}
+		if c.Executor.Kubernetes.Image == "" {
+			errs = append(errs, "kubernetes image is required")
+		}
+		if c.Executor.Kubernetes.Namespace == "" {
+			errs = append(errs, "kubernetes namespace is required")
+		}
+	default:
+		errs = append(errs, fmt.Sprintf("unknown executor type: %q (must be docker or kubernetes)", c.Executor.DefaultType))
+	}
+
+	// Store
+	if c.Store.Driver == "" {
+		errs = append(errs, "store driver is required")
+	}
+	if c.Store.DSN == "" {
+		errs = append(errs, "store DSN is required")
+	}
+
+	// Context
+	if c.Context.RefreshDays < 1 {
+		errs = append(errs, fmt.Sprintf("invalid context refresh days: %d (must be >= 1)", c.Context.RefreshDays))
+	}
+
+	if len(errs) > 0 {
+		return errors.New("config validation failed:\n  " + strings.Join(errs, "\n  "))
+	}
+	return nil
 }
 
 func envStr(key, fallback string) string {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -3,6 +3,7 @@ package config
 import (
 	"os"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -68,4 +69,96 @@ func TestLoadFromEnvDefaults(t *testing.T) {
 	assert.Equal(t, 8080, cfg.Server.Port)
 	assert.Equal(t, 5, cfg.Workers)
 	assert.Equal(t, "sqlite", cfg.Store.Driver)
+}
+
+func TestValidate_ValidConfig(t *testing.T) {
+	cfg := validConfig()
+	assert.NoError(t, cfg.Validate())
+}
+
+func TestValidate_Errors(t *testing.T) {
+	tests := []struct {
+		name   string
+		mutate func(*Config)
+		errMsg string
+	}{
+		{"zero port", func(c *Config) { c.Server.Port = 0 }, "invalid server port"},
+		{"port too high", func(c *Config) { c.Server.Port = 70000 }, "invalid server port"},
+		{"zero workers", func(c *Config) { c.Workers = 0 }, "invalid workers"},
+		{"missing app ID", func(c *Config) { c.GitHub.AppID = 0 }, "GITHUB_APP_ID is required"},
+		{"missing private key", func(c *Config) { c.GitHub.PrivateKeyPath = "" }, "GITHUB_PRIVATE_KEY_PATH is required"},
+		{"missing webhook secret", func(c *Config) { c.GitHub.WebhookSecret = "" }, "GITHUB_WEBHOOK_SECRET is required"},
+		{"missing claude key", func(c *Config) { c.LLM.Claude.APIKey = "" }, "ANTHROPIC_API_KEY is required"},
+		{"missing openai key", func(c *Config) {
+			c.LLM.DefaultProvider = "openai"
+			c.LLM.OpenAI.APIKey = ""
+		}, "OPENAI_API_KEY is required"},
+		{"bad provider", func(c *Config) { c.LLM.DefaultProvider = "gemini" }, "unknown LLM provider"},
+		{"bad executor", func(c *Config) { c.Executor.DefaultType = "podman" }, "unknown executor type"},
+		{"zero docker timeout", func(c *Config) { c.Executor.Docker.Timeout = 0 }, "docker timeout"},
+		{"missing docker image", func(c *Config) { c.Executor.Docker.Image = "" }, "docker image is required"},
+		{"zero k8s timeout", func(c *Config) {
+			c.Executor.DefaultType = "kubernetes"
+			c.Executor.Kubernetes = KubernetesConfig{
+				Image: "img:latest", Namespace: "default", Timeout: 0,
+			}
+		}, "kubernetes timeout"},
+		{"missing k8s image", func(c *Config) {
+			c.Executor.DefaultType = "kubernetes"
+			c.Executor.Kubernetes = KubernetesConfig{
+				Image: "", Namespace: "default", Timeout: 30 * time.Minute,
+			}
+		}, "kubernetes image is required"},
+		{"missing k8s namespace", func(c *Config) {
+			c.Executor.DefaultType = "kubernetes"
+			c.Executor.Kubernetes = KubernetesConfig{
+				Image: "img:latest", Namespace: "", Timeout: 30 * time.Minute,
+			}
+		}, "kubernetes namespace is required"},
+		{"missing store driver", func(c *Config) { c.Store.Driver = "" }, "store driver is required"},
+		{"missing store DSN", func(c *Config) { c.Store.DSN = "" }, "store DSN is required"},
+		{"zero refresh days", func(c *Config) { c.Context.RefreshDays = 0 }, "invalid context refresh days"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := validConfig()
+			tt.mutate(&cfg)
+			err := cfg.Validate()
+			assert.Error(t, err)
+			assert.Contains(t, err.Error(), tt.errMsg)
+		})
+	}
+}
+
+func TestValidate_MultipleErrors(t *testing.T) {
+	cfg := Config{} // zero-value config should trigger multiple errors
+	err := cfg.Validate()
+	assert.Error(t, err)
+	msg := err.Error()
+	assert.Contains(t, msg, "config validation failed:")
+	assert.Contains(t, msg, "invalid server port")
+	assert.Contains(t, msg, "invalid workers")
+	assert.Contains(t, msg, "GITHUB_APP_ID is required")
+	assert.Contains(t, msg, "store driver is required")
+}
+
+func validConfig() Config {
+	return Config{
+		Server:  ServerConfig{Port: 8080, Host: "0.0.0.0"},
+		Workers: 5,
+		GitHub: GitHubConfig{
+			AppID: 12345, PrivateKeyPath: "/path/to/key.pem", WebhookSecret: "secret",
+		},
+		LLM: LLMConfig{
+			DefaultProvider: "claude",
+			Claude:          ProviderConfig{APIKey: "sk-ant-test", Model: "claude-sonnet-4-5-20250514"},
+		},
+		Executor: ExecutorConfig{
+			DefaultType: "docker",
+			Docker:      DockerConfig{Image: "img:latest", Timeout: 30 * time.Minute},
+		},
+		Store:   StoreConfig{Driver: "sqlite", DSN: "neuralforge.db"},
+		Context: ContextConfig{AutoGenerate: true, RefreshDays: 7, AnalysisDepth: "thorough"},
+	}
 }


### PR DESCRIPTION
## Implementation for #11

**Issue:** MEDIUM: No configuration validation

### Approved Plan
Here is the implementation plan:

---

### Approach

Add a `Validate() error` method on `Config` that checks all critical fields after `LoadFromEnv()` populates them. Validation runs at startup in `serveCmd()`, failing fast with a clear error message before the app is constructed. The method collects all validation errors and returns them as a single combined error so the operator sees every problem at once rather than fixing them one at a time.

### Files to Modify

1. **`internal/config/config.go`** — Add `Validate()` method
2. **`internal/config/config_test.go`** — Add table-driven tests for `Validate()`
3. **`cmd/neuralforge/main.go`** — Call `cfg.Validate()` after `LoadFromEnv()`

### Implementation Steps

**Step 1: Add `Validate()` to `internal/config/config.go`**

Add `"errors"`, `"fmt"`, and `"strings"` to imports, then add a method after `LoadFromEnv()`:

```go
func (c Config) Validate() error {
	var errs []string

	// Server
	if c.Server.Port < 1 || c.Server.Port > 65535 {
		errs = append(errs, fmt.Sprintf("invalid server port: %d (must be 1-65535)", c.Server.Port))
	}

	// Workers
	if c.Workers < 1 {
		errs = append(errs, fmt.Sprintf("invalid workers: %d (must be >= 1)", c.Workers))
	}

	// GitHub — required for core functionality
	if c.GitHub.AppID == 0 {
		errs = append(errs, "GITHUB_APP_ID is required")
	}
	if c.GitHub.PrivateKeyPath == "" {
		errs = append(errs, "GITHUB_PRIVATE_KEY_PATH is required")
	}
	if c.GitHub.WebhookSecret == "" {
		errs = append(errs, "GITHUB_WEBHOOK_SECRET is required")
	}

	// LLM — validate the selected provider has an API key
	switch c.LLM.DefaultProvider {
	case "claude":
		if c.LLM.Claude.APIKey == "" {
			errs = append(errs, "ANTHROPIC_API_KEY is required when provider is claude")
		}
	case "openai":
		if c.LLM.OpenAI.APIKey == "" {
			errs = append(errs, "OPENAI_API_KEY is required when provider is openai")
		}
	default:
		errs = append(errs, fmt.Sprintf("unknown LLM provider: %q (must be claude or openai)", c.LLM.Defa

### Files Changed
- `cmd/neuralforge/main.go`
- `internal/config/config.go`
- `internal/config/config_test.go`

---
*Created by NeuralWarden Autopilot Issues Agent*