### PR TITLE
feat: implement #40 — FIX: Executor cleanup uses potentially-cancelled context

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -203,7 +203,9 @@ func (a *App) buildJobHandler() worker.JobHandler {
 		slog.Info("processing job", "job_id", job.ID, "repo", job.RepoFullName, "issue", job.IssueNumber)
 
 		defer func() {
-			if err := exec.Cleanup(ctx, job.ID); err != nil {
+			cleanupCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+			defer cancel()
+			if err := exec.Cleanup(cleanupCtx, job.ID); err != nil {
 				slog.Warn("executor cleanup failed", "job_id", job.ID, "executor", exec.Name(), "error", err)
 			}
 		}()


### PR DESCRIPTION
## Implementation for #40

**Issue:** FIX: Executor cleanup uses potentially-cancelled context

### Approved Plan
Good — `context` and `time` are already imported. I now have everything I need to produce the plan.

---

### Approach

Replace the deferred `exec.Cleanup(ctx, job.ID)` call in `buildJobHandler()` with a fresh `context.Background()`-derived context that has its own 30-second timeout. This ensures cleanup always runs even when the parent context has been cancelled due to job timeout or cancellation.

### Files to Modify

1. **`internal/app/app.go`** — the only file that needs to change.

### Implementation Steps

1. **Modify the defer block in `buildJobHandler()`** (`internal/app/app.go`, lines 205–209)

   **Current code:**
   ```go
   defer func() {
       if err := exec.Cleanup(ctx, job.ID); err != nil {
           slog.Warn("executor cleanup failed", "job_id", job.ID, "executor", exec.Name(), "error", err)
       }
   }()
   ```

   **Replace with:**
   ```go
   defer func() {
       cleanupCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
       defer cancel()
       if err := exec.Cleanup(cleanupCtx, job.ID); err != nil {
           slog.Warn("executor cleanup failed", "job_id", job.ID, "executor", exec.Name(), "error", err)
       }
   }()
   ```

   No new imports are needed — `context` and `time` are already imported in `app.go`.

### Testing

1. **Existing tests** — run `make test` to ensure no regressions.
2. **Manual verification** — the change is straightforward and mechanical: `context.Background()` replaces `ctx` as the parent. The 30-second timeout is a reasonable upper bound for `docker rm -f` or K8s API delete calls.
3. **To validate the fix end-to-end**: trigger a job that times out (or cancel one), then verify that the executor's resources (Docker containers or K8s Jobs/ConfigMaps) are properly cleaned up rather than accumulating.

### Risks

1. **30-second timeout too short** — If K8s API is extremely slow, the cleanup could still fail. 30 seconds is generous for a single `docker rm -f` or a couple of K8s API delete calls, 

### Files Changed
- `internal/app/app.go`

---
*Created by NeuralWarden Autopilot (event-driven recovery)*