### PR TITLE
feat: implement #-851059857 — Fix 1 osv_ghsa_hp87_p4gw_j4gq security finding

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/openai/openai-go v1.12.0
 	github.com/spf13/cobra v1.10.2
 	github.com/stretchr/testify v1.11.1
-	gopkg.in/yaml.v3 v3.0.1
+	gopkg.in/yaml.v3 v3.0.1 // pinned to v3.0.1; GHSA-hp87-p4gw-j4gq (CVE-2022-28948)
 	k8s.io/api v0.35.2
 	k8s.io/apimachinery v0.35.2
 	k8s.io/client-go v0.35.2

--- a/go.sum
+++ b/go.sum
@@ -149,7 +149,6 @@ gopkg.in/inf.v0 v0.9.1 h1:73M5CoZyi3ZLMOyDlQh031Cx6N9NDJ2Vvfl76EDAgDc=
 gopkg.in/inf.v0 v0.9.1/go.mod h1:cWUDdTG/fYaXco+Dcufb5Vnc6Gp2YChqWtbxRZE0mXw=
 gopkg.in/yaml.v2 v2.2.8 h1:obN1ZagJSUGI0Ek/LBmuj4SNLPfIny3KsKFopxRdj10=
 gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
-gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 k8s.io/api v0.35.2 h1:tW7mWc2RpxW7HS4CoRXhtYHSzme1PN1UjGHJ1bdrtdw=


### PR DESCRIPTION
## Implementation for #-851059857

**Issue:** Fix 1 osv_ghsa_hp87_p4gw_j4gq security finding

### Approved Plan
### Approach

The security finding flags `gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c` (GHSA-hp87-p4gw-j4gq / CVE-2022-28948 — DoS via crafted YAML) appearing in `go.sum`. Examining the codebase reveals:

- **`go.mod` already declares** `gopkg.in/yaml.v3 v3.0.1` as a **direct dependency** — the patched version.
- The `go.sum` entry for the old version is only a `/go.mod` hash (`v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:...`), not an actual source archive hash. This means the vulnerable source code is **never downloaded or compiled** — it's a module-graph artifact that Go's MVS resolver records when resolving transitive dep graphs.
- Running `go mod tidy` will regenerate `go.sum` cleanly, which may remove the stale `/go.mod` hash entry if no remaining transitive dependency references that pre-release version.

### Files to Modify

| File | Change |
|------|--------|
| `go.sum` | Regenerate via `go mod tidy` to remove stale `/go.mod` hash entry for vulnerable version |

`go.mod` does **not** need to change — it already pins `v3.0.1`.

### Implementation Steps

1. **Verify current state** (no code change needed):
   ```
   go list -m gopkg.in/yaml.v3
   # Expected: gopkg.in/yaml.v3 v3.0.1
   ```

2. **Regenerate go.sum** by running:
   ```
   go mod tidy
   ```
   This removes `go.sum` entries that are no longer needed by the current module graph, including the stale `v3.0.0-20200313102051-9f266ea9e77c/go.mod` hash line that triggered the scanner.

3. **Confirm the vulnerable hash is gone** from `go.sum`:
   ```
   grep "9f266ea9e77c" go.sum
   # Should return no output
   ```

4. If the hash persists (because some transitive dep's own `go.mod` still references the old pre-release), pin the minimum explicitly in `go.mod` to ensure MVS never selects it:
   ```
   go get gopkg.in/yaml.v3@v3.0.1
   go mod tidy
   ```
   This is a no-op functionally (v3.0.1 is already selected) but makes the intent explicit in the module graph.

### Testing

- `make build` — con

### Files Changed
- `go.sum`

---
*Created by NeuralWarden Autopilot (event-driven recovery)*