### PR TITLE
feat: implement #-424280409 — Fix 1 osv_go_2022_0603 security finding

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -149,7 +149,6 @@ gopkg.in/inf.v0 v0.9.1 h1:73M5CoZyi3ZLMOyDlQh031Cx6N9NDJ2Vvfl76EDAgDc=
 gopkg.in/inf.v0 v0.9.1/go.mod h1:cWUDdTG/fYaXco+Dcufb5Vnc6Gp2YChqWtbxRZE0mXw=
 gopkg.in/yaml.v2 v2.2.8 h1:obN1ZagJSUGI0Ek/LBmuj4SNLPfIny3KsKFopxRdj10=
 gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
-gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 k8s.io/api v0.35.2 h1:tW7mWc2RpxW7HS4CoRXhtYHSzme1PN1UjGHJ1bdrtdw=


### PR DESCRIPTION
## Implementation for #-424280409

**Issue:** Fix 1 osv_go_2022_0603 security finding

### Approved Plan
### Approach

The security scanner flags `gopkg.in/yaml.v3 3.0.0-20200313102051-9f266ea9e77c` in `go.sum`. However, `go.mod` already declares `gopkg.in/yaml.v3 v3.0.1` as a direct dependency — the patched release. The go.sum entry for the old pre-release version exists only as a `/go.mod` hash (not source), kept because a transitive dependency's own go.mod still references that old pseudo-version. Running `go mod tidy` will remove unnecessary go.sum entries where possible, and since `v3.0.1` is already the resolved version via Go's MVS, no vulnerable code is compiled in.

### Files to Modify

- `go.sum` — remove the stale pre-release hash entry by running `go mod tidy`

### Implementation Steps

1. **Confirm current state** — verify `go.mod` already pins `gopkg.in/yaml.v3 v3.0.1` (confirmed: line 11 of go.mod).

2. **Run `go mod tidy`** — this removes stale entries from `go.sum` that are no longer needed. If the entry `gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:...` is orphaned (i.e., no remaining transitive dep references it), it will be dropped.

   ```bash
   go mod tidy
   ```

3. **Inspect result** — if the entry persists after tidy, it means a transitive dependency (likely one of the k8s.io or other indirect deps) still declares `require gopkg.in/yaml.v3 v3.0.0-20200313...` in its own go.mod. In that case:

   a. Identify which dep still references the old version:
   ```bash
   go mod graph | grep "yaml.v3 v3.0.0"
   ```

   b. Update that indirect dep if a newer version is available that pulls in yaml.v3 v3.0.1. Otherwise, the entry is Go's normal book-keeping for MVS and the actual compiled version remains v3.0.1 (safe).

   c. If the entry cannot be removed (locked by upstream), add a `replace` directive or an explicit `require` override — but since go.mod already has `v3.0.1` as a direct dependency, MVS already selects v3.0.1 at build time, making the vulnerability unexploitable regardless.

4. **Re-run the scanner** — after `go mod tid

### Files Changed
- `go.sum`

---
*Created by NeuralWarden Autopilot (event-driven recovery)*