### PR TITLE
feat: implement #-824190191 — Fix 1 llm_010 security finding

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -163,19 +163,14 @@ func (a *App) handleEvent(eventType string, payload []byte) {
 	}
 }
 
-// healthHandler handles GET /health. It returns a minimal response and
-// intentionally excludes model names, provider info, API keys, and any LLM
-// configuration to comply with llm_010 (do not serve model metadata publicly).
+// healthHandler handles GET /health with a minimal status response.
 func healthHandler(w http.ResponseWriter, r *http.Request) {
-	// Only GET is meaningful for a health check; reject others.
 	if r.Method != http.MethodGet {
 		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
 		return
 	}
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
-	// Intentionally minimal: do NOT include model names, provider info,
-	// API keys, or any LLM configuration (llm_010).
 	if _, err := w.Write([]byte(`{"status":"ok"}`)); err != nil {
 		slog.Error("failed to write health response", "error", err)
 	}

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -78,12 +78,7 @@ func New(cfg config.Config) (*App, error) {
 	} else {
 		mux.Handle("/webhooks/github", NewWebhookHandler(cfg.GitHub.WebhookSecret, a.handleEvent))
 	}
-	mux.HandleFunc("/health", func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusOK)
-		if _, err := w.Write([]byte(`{"status":"ok"}`)); err != nil {
-			slog.Error("failed to write health response", "error", err)
-		}
-	})
+	mux.HandleFunc("/health", healthHandler)
 
 	a.server = &http.Server{
 		Addr:    fmt.Sprintf("%s:%d", cfg.Server.Host, cfg.Server.Port),
@@ -165,6 +160,24 @@ func (a *App) handleEvent(eventType string, payload []byte) {
 		slog.Info("job created", "job_id", jobID, "issue", e.Issue.Title)
 	default:
 		slog.Info("unhandled event type", "type", event.EventType())
+	}
+}
+
+// healthHandler handles GET /health. It returns a minimal response and
+// intentionally excludes model names, provider info, API keys, and any LLM
+// configuration to comply with llm_010 (do not serve model metadata publicly).
+func healthHandler(w http.ResponseWriter, r *http.Request) {
+	// Only GET is meaningful for a health check; reject others.
+	if r.Method != http.MethodGet {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	// Intentionally minimal: do NOT include model names, provider info,
+	// API keys, or any LLM configuration (llm_010).
+	if _, err := w.Write([]byte(`{"status":"ok"}`)); err != nil {
+		slog.Error("failed to write health response", "error", err)
 	}
 }
 


### PR DESCRIPTION
## Implementation for #-824190191

**Issue:** Fix 1 llm_010 security finding

### Approved Plan
### Approach

The security finding `llm_010` references `api/schemas.py:562`, but **this file does not exist in this Go codebase**. The scanner has produced a misattributed finding — this is a Python-style rule applied to a Go project. After thorough review of all HTTP endpoints and LLM-related code, the current codebase has no path that serves raw model files or exposes model metadata publicly.

Nevertheless, to address the spirit of the finding ("Restrict model access with authentication. Do not serve raw model files publicly."), the most relevant surface area in this codebase is the public `/health` endpoint in `internal/app/app.go`. Currently it returns only `{"status":"ok"}`, but it has no guards preventing future contributors from accidentally leaking LLM configuration (model names, provider info) through it unauthenticated.

The fix is minimal: add a structured health response that explicitly limits what is returned and ensure no model metadata is included.

---

### Files to Modify

- **`internal/app/app.go`** — The only file with public-facing HTTP handler logic.

---

### Implementation Steps

1. **Confirm the finding's file is absent**
   - `api/schemas.py` does not exist; the scanner finding is a false positive for this repository. No Python file needs modification.

2. **Audit all HTTP endpoints for model information exposure**
   - `/webhooks/github` — authenticated via HMAC/GitHub App middleware. Does not expose model info. ✓
   - `/health` — public, unauthenticated. Currently returns only `{"status":"ok"}`. ✓

3. **Harden the `/health` handler in `internal/app/app.go` (lines 81–86)**

   The handler currently is:
   ```go
   mux.HandleFunc("/health", func(w http.ResponseWriter, r *http.Request) {
       w.WriteHeader(http.StatusOK)
       if _, err := w.Write([]byte(`{"status":"ok"}`)); err != nil {
           slog.Error("failed to write health response", "error", err)
       }
   })
   ```

   Replace with a dedicated named handler that sets an expl

### Files Changed
- `internal/app/app.go`

---
*Created by NeuralWarden Autopilot (event-driven recovery)*