### PR TITLE
feat: implement #-509260048 — Fix 9 agent_sec_002 security findings

### DIFF
--- a/internal/llm/claude.go
+++ b/internal/llm/claude.go
@@ -3,6 +3,7 @@ package llm
 import (
 	"context"
 	"fmt"
+	"log/slog"
 
 	anthropic "github.com/anthropics/anthropic-sdk-go"
 	"github.com/anthropics/anthropic-sdk-go/option"
@@ -31,6 +32,8 @@ func (c *ClaudeBackend) Complete(ctx context.Context, req CompletionRequest) (Co
 	if model == "" {
 		model = c.model
 	}
+
+	slog.Info("llm call", "backend", "claude", "agent", req.AgentName, "model", model)
 
 	maxTokens := int64(req.MaxTokens)
 	if maxTokens == 0 {

--- a/internal/llm/llm.go
+++ b/internal/llm/llm.go
@@ -16,6 +16,7 @@ type Message struct {
 }
 
 type CompletionRequest struct {
+	AgentName   string    `json:"agent_name"`
 	System      string    `json:"system"`
 	Messages    []Message `json:"messages"`
 	Model       string    `json:"model"`

--- a/internal/llm/openai.go
+++ b/internal/llm/openai.go
@@ -3,6 +3,7 @@ package llm
 import (
 	"context"
 	"fmt"
+	"log/slog"
 
 	openai "github.com/openai/openai-go"
 	"github.com/openai/openai-go/option"
@@ -31,6 +32,8 @@ func (o *OpenAIBackend) Complete(ctx context.Context, req CompletionRequest) (Co
 	if model == "" {
 		model = o.model
 	}
+
+	slog.Info("llm call", "backend", "openai", "agent", req.AgentName, "model", model)
 
 	// Build messages, prepending system message if provided
 	var msgs []openai.ChatCompletionMessageParamUnion

--- a/internal/pipeline/architect.go
+++ b/internal/pipeline/architect.go
@@ -29,7 +29,8 @@ func (s *ArchitectStage) Run(ctx context.Context, state *PipelineState) (StageRe
 	)
 
 	resp, err := s.llm.Complete(ctx, llm.CompletionRequest{
-		System: "You are a software architect creating implementation plans.",
+		AgentName: "architect",
+		System:    "You are a software architect creating implementation plans.",
 		Messages: []llm.Message{
 			{Role: llm.RoleUser, Content: prompt},
 		},

--- a/internal/pipeline/review.go
+++ b/internal/pipeline/review.go
@@ -53,7 +53,8 @@ func (s *ReviewStage) Run(ctx context.Context, state *PipelineState) (StageResul
 	)
 
 	resp, err := s.llm.Complete(ctx, llm.CompletionRequest{
-		System: "You are a code reviewer. Start your response with APPROVE or REQUEST_CHANGES.",
+		AgentName: "review",
+		System:    "You are a code reviewer. Start your response with APPROVE or REQUEST_CHANGES.",
 		Messages: []llm.Message{
 			{Role: llm.RoleUser, Content: prompt},
 		},

--- a/internal/pipeline/security.go
+++ b/internal/pipeline/security.go
@@ -36,7 +36,8 @@ func (s *SecurityStage) Run(ctx context.Context, state *PipelineState) (StageRes
 	)
 
 	resp, err := s.llm.Complete(ctx, llm.CompletionRequest{
-		System: "You are a security reviewer analyzing implementation plans for vulnerabilities.",
+		AgentName: "security",
+		System:    "You are a security reviewer analyzing implementation plans for vulnerabilities.",
 		Messages: []llm.Message{
 			{Role: llm.RoleUser, Content: prompt},
 		},


### PR DESCRIPTION
## Implementation for #-509260048

**Issue:** Fix 9 agent_sec_002 security findings

### Approved Plan
Now I have a complete picture. The referenced Python files (`api/llm_sast_scanner.py`, `api/autopilot/review_rules.py`, `pipeline/config.py`, `pipeline/llm_factory.py`) do not exist in this Go repository. The intent of the findings maps to the Go codebase: `CompletionRequest` in `internal/llm/llm.go` has no `AgentName` field, so LLM calls made by pipeline stages cannot be attributed in audit logs.

---

### Approach

Add an `AgentName string` field to `CompletionRequest` and populate it at each `llm.Complete()` call site in the pipeline stages. The LLM backends (`claude.go`, `openai.go`) will emit a structured log entry including the agent name on every call, enabling per-agent attribution in audit logs.

### Files to Modify

1. `internal/llm/llm.go` — Add `AgentName` field to `CompletionRequest`
2. `internal/llm/claude.go` — Log `AgentName` in `Complete()`
3. `internal/llm/openai.go` — Log `AgentName` in `Complete()`
4. `internal/pipeline/architect.go` — Set `AgentName: "architect"`
5. `internal/pipeline/review.go` — Set `AgentName: "review"`
6. `internal/pipeline/security.go` — Set `AgentName: "security"`

### Implementation Steps

1. **`internal/llm/llm.go`** — Extend `CompletionRequest`:
   ```go
   type CompletionRequest struct {
       AgentName   string    `json:"agent_name"`   // add this field
       System      string    `json:"system"`
       Messages    []Message `json:"messages"`
       Model       string    `json:"model"`
       MaxTokens   int       `json:"max_tokens"`
       Temperature float64   `json:"temperature"`
   }
   ```

2. **`internal/llm/claude.go`** — At the top of `Complete()`, before the API call, add:
   ```go
   slog.Info("llm call", "backend", "claude", "agent", req.AgentName, "model", model)
   ```
   Requires adding `"log/slog"` to the import block.

3. **`internal/llm/openai.go`** — Same pattern at the top of `Complete()`:
   ```go
   slog.Info("llm call", "backend", "openai", "agent", req.AgentName, "model", model)
   ```
   Requ

### Files Changed
- `internal/llm/claude.go`
- `internal/llm/llm.go`
- `internal/llm/openai.go`
- `internal/pipeline/architect.go`
- `internal/pipeline/review.go`
- `internal/pipeline/security.go`

---
*Created by NeuralWarden Autopilot (event-driven recovery)*