### PR TITLE
feat: implement #-424240899 — Fix 25 llm_004 security findings

### DIFF
--- a/internal/llm/openai.go
+++ b/internal/llm/openai.go
@@ -3,6 +3,7 @@ package llm
 import (
 	"context"
 	"fmt"
+	"log"
 
 	openai "github.com/openai/openai-go"
 	"github.com/openai/openai-go/option"
@@ -56,6 +57,7 @@ func (o *OpenAIBackend) Complete(ctx context.Context, req CompletionRequest) (Co
 	maxTokens := int64(req.MaxTokens)
 	if maxTokens == 0 {
 		maxTokens = 4096
+		log.Printf("openai: max_tokens not set by caller, applying default of %d to prevent resource exhaustion", maxTokens)
 	}
 	params.MaxCompletionTokens = param.NewOpt(maxTokens)
 

--- a/internal/llm/openai.go
+++ b/internal/llm/openai.go
@@ -53,9 +53,11 @@ func (o *OpenAIBackend) Complete(ctx context.Context, req CompletionRequest) (Co
 		Messages: msgs,
 	}
 
-	if req.MaxTokens > 0 {
-		params.MaxCompletionTokens = param.NewOpt(int64(req.MaxTokens))
+	maxTokens := int64(req.MaxTokens)
+	if maxTokens == 0 {
+		maxTokens = 4096
 	}
+	params.MaxCompletionTokens = param.NewOpt(maxTokens)
 
 	if req.Temperature > 0 {
 		params.Temperature = param.NewOpt(req.Temperature)


### PR DESCRIPTION
## Implementation for #-424240899

**Issue:** Fix 25 llm_004 security findings

### Approved Plan
### Approach

The 25 security findings reference Python files (`api/llm_sast_scanner.py`, `pipeline/litellm_adapter.py`, etc.) that **do not exist** in this Go-only repository. The scan results belong to a different codebase. However, the underlying security concern — LLM calls without an enforced `max_tokens` limit — does apply partially to the Go code: `openai.go` does **not** set a fallback token limit when `req.MaxTokens == 0`, unlike `claude.go` which already defaults to 4096.

The plan fixes the real gap in the Go codebase (the OpenAI backend's missing default) while noting the Python files are absent.

---

### Files to Modify

| File | Change |
|------|--------|
| `internal/llm/openai.go` | Add a default `MaxCompletionTokens` of 4096 when `req.MaxTokens == 0`, mirroring `claude.go` |

No other files require changes: `architect.go`, `review.go`, and `security.go` already pass explicit `MaxTokens` values; `claude.go` already enforces a default.

---

### Implementation Steps

**1. `internal/llm/openai.go` — enforce a default max_tokens**

Current code (lines 56-58):
```go
if req.MaxTokens > 0 {
    params.MaxCompletionTokens = param.NewOpt(int64(req.MaxTokens))
}
```

Replace with:
```go
maxTokens := int64(req.MaxTokens)
if maxTokens == 0 {
    maxTokens = 4096
}
params.MaxCompletionTokens = param.NewOpt(maxTokens)
```

This unconditionally sets `MaxCompletionTokens`, defaulting to 4096 when the caller does not specify a value — identical to the pattern already used in `claude.go` (lines 35-38).

---

### Testing

- `make test` / `go test ./internal/llm/... -v` — ensure existing tests pass.
- Add a unit test case in `internal/llm/` (or extend an existing test) that calls `Complete` with `req.MaxTokens == 0` via the OpenAI backend and asserts that `params.MaxCompletionTokens` is set to 4096 (this can be tested with a mock transport or by inspecting the constructed params before the HTTP call).

---

### Risks

- **Python findings are not addressable here** — th

### Files Changed
- `internal/llm/openai.go`

---
*Created by NeuralWarden Autopilot (event-driven recovery)*