### PR TITLE
feat: implement #-4313651 — Fix 1 osv_ghsa_3ppc_4f35_3m26 security finding

### DIFF
--- a/docs/security-false-positives.md
+++ b/docs/security-false-positives.md
@@ -1,0 +1,15 @@
+# Security False Positives
+
+This file documents security scanner findings that are false positives for this repository.
+
+## GHSA-3ppc-4f35-3m26 — minimatch ReDoS (npm)
+
+- **Scanner finding:** `minimatch@9.0.5` in `frontend/package-lock.json`
+- **CVSS:** 5.0 (Medium)
+- **Status:** False positive — `frontend/package-lock.json` does not exist in this repository.
+
+**Explanation:** This is a pure Go project. There is no `frontend/` directory, no `package.json`, and no `package-lock.json`. The referenced lockfile path does not exist, so this finding does not apply.
+
+**Action required:** None. Dismiss this finding in the scanner.
+
+**Future guidance:** If a `frontend/` directory is added, include `npm audit --audit-level=moderate` in CI to catch npm vulnerabilities at that time.


### PR DESCRIPTION
## Implementation for #-4313651

**Issue:** Fix 1 osv_ghsa_3ppc_4f35_3m26 security finding

### Approved Plan
### Approach

The security finding flags `minimatch@9.0.5` in `frontend/package-lock.json` (GHSA-3ppc-4f35-3m26, a ReDoS vulnerability). However, inspecting the repository reveals **no `frontend/` directory and no `package.json` or `package-lock.json` files exist** — this is a pure Go project. The finding is a false positive: the referenced lockfile path does not exist in this repo.

The correct remediation is to confirm the file is absent and document that no action is needed in this repository. If a frontend directory was once present and removed, there is nothing to patch. If it will be added in the future, the guidance below applies at that time.

---

### Files to Modify

None — the vulnerable file (`frontend/package-lock.json`) does not exist in this repository.

If the file did exist, the only change would be:

| File | Change |
|------|--------|
| `frontend/package-lock.json` | Upgrade `minimatch` from `9.0.5` to `≥9.0.5` patched version (e.g. `9.0.6` or later that includes the ReDoS fix) |
| `frontend/package.json` | Update the `minimatch` version constraint if it is a direct dependency |

---

### Implementation Steps

1. **Verify absence of the file** — Confirm `frontend/package-lock.json` does not exist. (Confirmed: repository root contains only Go source, `Makefile`, `Dockerfile`, `go.mod`, `go.sum`, and deployment files.)

2. **If the file were present, the fix would be:**
   - Run `npm install minimatch@latest` (or the specific patched version) inside `frontend/`
   - Commit the updated `package-lock.json`
   - Verify with `npm audit` that the finding is resolved

3. **Close the finding as a false positive** — Report back to the scanner that `frontend/package-lock.json` does not exist in this repository and the finding should be dismissed.

---

### Testing

- Run `ls frontend/` — confirms the directory does not exist, verifying this is a false positive.
- If a frontend were added: run `npm audit` inside `frontend/` and confirm zero high/medium findin

### Files Changed
- `docs/security-false-positives.md`

---
*Created by NeuralWarden Autopilot (event-driven recovery)*