### PR TITLE
feat: implement #-880842782 — Fix 10 agent_sec_001 security findings

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -171,14 +171,12 @@ func (a *App) handleEvent(eventType string, payload []byte) {
 // buildJobHandler creates the LLM backend and executor, then returns a handler
 // that clones the repo, builds pipeline state, and runs the pipeline engine.
 func (a *App) buildJobHandler() worker.JobHandler {
-	// Create LLM backend based on config.
-	var backend llm.LLM
-	switch a.cfg.LLM.DefaultProvider {
-	case "openai":
-		backend = llm.NewOpenAI(a.cfg.LLM.OpenAI.APIKey, a.cfg.LLM.OpenAI.Model)
-	default:
-		backend = llm.NewClaude(a.cfg.LLM.Claude.APIKey, a.cfg.LLM.Claude.Model)
+	// Create LLM backend based on config, wrapped with audit logging.
+	apiKey, model := a.cfg.LLM.Claude.APIKey, a.cfg.LLM.Claude.Model
+	if a.cfg.LLM.DefaultProvider == "openai" {
+		apiKey, model = a.cfg.LLM.OpenAI.APIKey, a.cfg.LLM.OpenAI.Model
 	}
+	backend := llm.New(a.cfg.LLM.DefaultProvider, apiKey, model)
 
 	// Create executor based on config.
 	var exec executor.Executor

--- a/internal/llm/audit.go
+++ b/internal/llm/audit.go
@@ -1,0 +1,66 @@
+package llm
+
+import (
+	"context"
+	"log/slog"
+	"time"
+)
+
+// AuditedLLM wraps any LLM and emits structured slog entries for every call.
+type AuditedLLM struct {
+	inner LLM
+}
+
+// NewAudited wraps inner with audit logging.
+func NewAudited(inner LLM) *AuditedLLM {
+	slog.Info("llm client created", "provider", inner.Name())
+	return &AuditedLLM{inner: inner}
+}
+
+func (a *AuditedLLM) Name() string { return a.inner.Name() }
+
+func (a *AuditedLLM) Complete(ctx context.Context, req CompletionRequest) (CompletionResponse, error) {
+	start := time.Now()
+	slog.Info("llm complete start",
+		"provider", a.inner.Name(),
+		"model", req.Model,
+		"max_tokens", req.MaxTokens,
+	)
+	resp, err := a.inner.Complete(ctx, req)
+	if err != nil {
+		slog.Error("llm complete error",
+			"provider", a.inner.Name(),
+			"error", err,
+			"duration_ms", time.Since(start).Milliseconds(),
+		)
+		return resp, err
+	}
+	slog.Info("llm complete ok",
+		"provider", a.inner.Name(),
+		"model", resp.Model,
+		"input_tokens", resp.InputTokens,
+		"output_tokens", resp.OutputTokens,
+		"cost_usd", resp.Cost,
+		"duration_ms", time.Since(start).Milliseconds(),
+	)
+	return resp, nil
+}
+
+func (a *AuditedLLM) StreamComplete(ctx context.Context, req CompletionRequest) (<-chan StreamChunk, error) {
+	slog.Info("llm stream start", "provider", a.inner.Name(), "model", req.Model)
+	return a.inner.StreamComplete(ctx, req)
+}
+
+// New is the authoritative factory for creating audited LLM clients.
+// provider is "openai" or "claude" (default). apiKey and model are forwarded
+// to the backend constructor.
+func New(provider, apiKey, model string) LLM {
+	var backend LLM
+	switch provider {
+	case "openai":
+		backend = NewOpenAI(apiKey, model)
+	default:
+		backend = NewClaude(apiKey, model)
+	}
+	return NewAudited(backend)
+}

--- a/internal/llm/audit.go
+++ b/internal/llm/audit.go
@@ -1,3 +1,24 @@
+// Package llm provides LLM client implementations and an auditing wrapper.
+//
+// # Audit Logging — Data Minimization Policy
+//
+// AuditedLLM logs only operational metadata to satisfy HIPAA §164.312(b),
+// GDPR Article 32, and PCI-DSS Requirement 3.4. The following fields are
+// deliberately excluded from all log entries to prevent PHI/PAN/personal-data
+// leakage:
+//
+//   - CompletionRequest.System     (may contain user instructions with PII)
+//   - CompletionRequest.Messages   (may contain PHI, PAN, or personal data)
+//   - CompletionResponse.Content   (may contain derived/reflected sensitive data)
+//
+// Only the following non-content operational fields are logged:
+//
+//   - provider name, model identifier, max_tokens (request sizing)
+//   - input_tokens, output_tokens, cost_usd, duration_ms (billing/performance)
+//
+// These fields contain no user-supplied data and carry negligible re-identification
+// risk. If the deployment context requires stricter controls (e.g., zero-log mode),
+// replace NewAudited with a no-op wrapper before calling llm.New.
 package llm
 
 import (
@@ -7,6 +28,7 @@ import (
 )
 
 // AuditedLLM wraps any LLM and emits structured slog entries for every call.
+// See package-level documentation for the data minimization policy.
 type AuditedLLM struct {
 	inner LLM
 }
@@ -47,8 +69,45 @@ func (a *AuditedLLM) Complete(ctx context.Context, req CompletionRequest) (Compl
 }
 
 func (a *AuditedLLM) StreamComplete(ctx context.Context, req CompletionRequest) (<-chan StreamChunk, error) {
-	slog.Info("llm stream start", "provider", a.inner.Name(), "model", req.Model)
-	return a.inner.StreamComplete(ctx, req)
+	start := time.Now()
+	provider := a.inner.Name()
+	slog.Info("llm stream start", "provider", provider, "model", req.Model)
+
+	inner, err := a.inner.StreamComplete(ctx, req)
+	if err != nil {
+		slog.Error("llm stream error",
+			"provider", provider,
+			"model", req.Model,
+			"error", err,
+			"duration_ms", time.Since(start).Milliseconds(),
+		)
+		return nil, err
+	}
+
+	// Wrap the channel so we can emit a completion audit event when streaming ends.
+	out := make(chan StreamChunk)
+	go func() {
+		defer close(out)
+		for chunk := range inner {
+			out <- chunk
+			if chunk.Done {
+				slog.Info("llm stream ok",
+					"provider", provider,
+					"model", req.Model,
+					"duration_ms", time.Since(start).Milliseconds(),
+				)
+			}
+			if chunk.Error != nil {
+				slog.Error("llm stream chunk error",
+					"provider", provider,
+					"model", req.Model,
+					"error", chunk.Error,
+					"duration_ms", time.Since(start).Milliseconds(),
+				)
+			}
+		}
+	}()
+	return out, nil
 }
 
 // New is the authoritative factory for creating audited LLM clients.

--- a/internal/llm/audit_test.go
+++ b/internal/llm/audit_test.go
@@ -19,7 +19,14 @@ func (m *mockLLM) Complete(_ context.Context, _ CompletionRequest) (CompletionRe
 	return m.resp, m.err
 }
 func (m *mockLLM) StreamComplete(_ context.Context, _ CompletionRequest) (<-chan StreamChunk, error) {
-	return nil, nil
+	if m.err != nil {
+		return nil, m.err
+	}
+	ch := make(chan StreamChunk, 2)
+	ch <- StreamChunk{Content: "hello"}
+	ch <- StreamChunk{Content: " world", Done: true}
+	close(ch)
+	return ch, nil
 }
 
 func TestAuditedLLM_Complete(t *testing.T) {
@@ -50,6 +57,27 @@ func TestAuditedLLM_Complete(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestAuditedLLM_StreamComplete(t *testing.T) {
+	t.Run("success emits all chunks", func(t *testing.T) {
+		a := NewAudited(&mockLLM{name: "mock"})
+		ch, err := a.StreamComplete(context.Background(), CompletionRequest{})
+		assert.NoError(t, err)
+		var chunks []StreamChunk
+		for c := range ch {
+			chunks = append(chunks, c)
+		}
+		assert.Len(t, chunks, 2)
+		assert.True(t, chunks[1].Done)
+	})
+
+	t.Run("error propagated", func(t *testing.T) {
+		a := NewAudited(&mockLLM{name: "mock", err: fmt.Errorf("stream fail")})
+		ch, err := a.StreamComplete(context.Background(), CompletionRequest{})
+		assert.Error(t, err)
+		assert.Nil(t, ch)
+	})
 }
 
 func TestNew(t *testing.T) {

--- a/internal/llm/audit_test.go
+++ b/internal/llm/audit_test.go
@@ -1,0 +1,62 @@
+package llm
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type mockLLM struct {
+	name string
+	resp CompletionResponse
+	err  error
+}
+
+func (m *mockLLM) Name() string { return m.name }
+func (m *mockLLM) Complete(_ context.Context, _ CompletionRequest) (CompletionResponse, error) {
+	return m.resp, m.err
+}
+func (m *mockLLM) StreamComplete(_ context.Context, _ CompletionRequest) (<-chan StreamChunk, error) {
+	return nil, nil
+}
+
+func TestAuditedLLM_Complete(t *testing.T) {
+	tests := []struct {
+		name    string
+		inner   LLM
+		wantErr bool
+	}{
+		{
+			name:  "success",
+			inner: &mockLLM{name: "mock", resp: CompletionResponse{Content: "hi", Model: "m"}},
+		},
+		{
+			name:    "error propagated",
+			inner:   &mockLLM{name: "mock", err: fmt.Errorf("fail")},
+			wantErr: true,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			a := NewAudited(tc.inner)
+			assert.Equal(t, "mock", a.Name())
+			_, err := a.Complete(context.Background(), CompletionRequest{})
+			if tc.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestNew(t *testing.T) {
+	// Verify New returns an *AuditedLLM for both providers
+	for _, provider := range []string{"openai", "claude"} {
+		client := New(provider, "key", "model")
+		_, ok := client.(*AuditedLLM)
+		assert.True(t, ok, "expected AuditedLLM for provider %s", provider)
+	}
+}


### PR DESCRIPTION
## Implementation for #-880842782

**Issue:** Fix 10 agent_sec_001 security findings

### Approved Plan
Now I have enough context to write the implementation plan. Findings 3–10 reference Python and frontend files that do not exist in this repository — only findings 1 and 2 are in-scope for this Go codebase.

---

### Approach

Introduce an auditing wrapper (`AuditedLLM`) that implements the `llm.LLM` interface and emits structured `slog` log entries on every `Complete` / `StreamComplete` call. Provide a single factory function (`llm.New`) that constructs the correct backend and wraps it with `AuditedLLM`. Replace all direct `llm.NewOpenAI` / `llm.NewClaude` call-sites in `app.go` with the factory function.

Findings 3–10 reference files (`api/secret_patterns.py`, `api/autopilot/workers/issue_agent.py`, `api/llm/vm_proxy_client.py`, `frontend/src/lib/docs-content.tsx`, `pipeline/llm_factory.py`) that do not exist in this repository and are therefore out of scope for this PR.

---

### Files to Modify

| File | Action |
|---|---|
| `internal/llm/audit.go` | **Create** — `AuditedLLM` wrapper + `New` factory |
| `internal/llm/audit_test.go` | **Create** — table-driven tests for `AuditedLLM` |
| `internal/app/app.go` | **Modify** — replace direct `llm.NewOpenAI` / `llm.NewClaude` with `llm.New` |

---

### Implementation Steps

**Step 1 — `internal/llm/audit.go`**

Create the file with two exported symbols:

```go
package llm

import (
    "context"
    "log/slog"
    "time"
)

// AuditedLLM wraps any LLM and emits structured slog entries for every call.
type AuditedLLM struct {
    inner LLM
}

// NewAudited wraps inner with audit logging.
func NewAudited(inner LLM) *AuditedLLM {
    slog.Info("llm client created", "provider", inner.Name())
    return &AuditedLLM{inner: inner}
}

func (a *AuditedLLM) Name() string { return a.inner.Name() }

func (a *AuditedLLM) Complete(ctx context.Context, req CompletionRequest) (CompletionResponse, error) {
    start := time.Now()
    slog.Info("llm complete start",
        "provider", a.inner.Name(),
        "model", req.Model,
      

### Files Changed
- `internal/app/app.go`
- `internal/llm/audit.go`
- `internal/llm/audit_test.go`

---
*Created by NeuralWarden Autopilot (event-driven recovery)*