### PR TITLE
feat: implement #-843455239 — Fix 1 osv_go_2022_0603 security finding

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -149,7 +149,6 @@ gopkg.in/inf.v0 v0.9.1 h1:73M5CoZyi3ZLMOyDlQh031Cx6N9NDJ2Vvfl76EDAgDc=
 gopkg.in/inf.v0 v0.9.1/go.mod h1:cWUDdTG/fYaXco+Dcufb5Vnc6Gp2YChqWtbxRZE0mXw=
 gopkg.in/yaml.v2 v2.2.8 h1:obN1ZagJSUGI0Ek/LBmuj4SNLPfIny3KsKFopxRdj10=
 gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
-gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 k8s.io/api v0.35.2 h1:tW7mWc2RpxW7HS4CoRXhtYHSzme1PN1UjGHJ1bdrtdw=


### PR DESCRIPTION
## Implementation for #-843455239

**Issue:** Fix 1 osv_go_2022_0603 security finding

### Approved Plan
### Approach

The security finding `GO-2022-0603` refers to a denial-of-service vulnerability (uncontrolled resource consumption via malicious YAML input) in `gopkg.in/yaml.v3` versions prior to `v3.0.1`. 

The `go.mod` already declares `gopkg.in/yaml.v3 v3.0.1` (the patched version). The scanner flagged `go.sum` line 152:
```
gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
```
This is **only a `go.mod` hash** (not a source hash) — it means Go downloaded that version's `go.mod` to resolve the dependency graph but did **not** compile the vulnerable code. The actual source compiled is `v3.0.1`. However, the OSV scanner treats the presence of this hash as a finding and it must be removed to close the issue.

The fix is to run `go mod tidy` to clean up stale `go.sum` entries. If the entry persists (because a transitive dependency's `go.mod` still references it), a `go.sum` `replace` or explicit `go get` upgrade of the originating transitive dep may be needed.

---

### Files to Modify

| File | Change |
|------|--------|
| `go.sum` | Remove the `gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod` entry via `go mod tidy` |
| `go.mod` | Confirm/retain `gopkg.in/yaml.v3 v3.0.1` (already correct; no change needed unless tidy alters it) |

---

### Implementation Steps

1. **Confirm current state**: Verify `go.mod` already specifies `gopkg.in/yaml.v3 v3.0.1` (confirmed — line 11 of `go.mod`).

2. **Run `go mod tidy`**:
   ```bash
   go mod tidy
   ```
   This prunes unused or stale entries from `go.sum`. If `v3.0.0-20200313102051-9f266ea9e77c/go.mod` is no longer needed by any module graph path, it will be removed.

3. **Check if entry persists** after tidy. If it does, identify which transitive dependency's `go.mod` still references that version:
   ```bash
   go mod graph | grep yaml.v3
   ```

4. **If the entry persists** (because a transitive dep requires that old version in its own `go.mod`): upgrade the

### Files Changed
- `go.sum`

---
*Created by NeuralWarden Autopilot (event-driven recovery)*