### PR TITLE
feat: implement #-174570969 — Fix 1 osv_ghsa_2g4f_4pwh_qvx6 security finding

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,0 +1,15 @@
+{
+  "name": "neuralforge-frontend",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "neuralforge-frontend",
+      "version": "1.0.0",
+      "overrides": {
+        "ajv": "^8.17.1"
+      }
+    }
+  }
+}

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -7,8 +7,61 @@
     "": {
       "name": "neuralforge-frontend",
       "version": "1.0.0",
+      "devDependencies": {
+        "ajv": "^8.17.1"
+      },
       "overrides": {
         "ajv": "^8.17.1"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
+      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0Szwi1H31hK7GOQFLujFy1FuME6X5gHZNWmh6DaHVkn4aFJQ68nKGEGBXFDPGw==",
+      "dev": true,
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gauWwYosxz3dLAbfq5Mn35+l1znNfDlNGbCHqCUFQ5qlpk4w8w0oQ==",
+      "dev": true
+    },
+    "node_modules/fast-uri": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.0.6.tgz",
+      "integrity": "sha512-Atfo14OibSv5wAp4VWNsFYE1AchQRTv9cBGWET4pZWHzYshFSS9NQI6I57rdKn9croWVMvspsIzpxkU+2+dew==",
+      "dev": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nicolo-ribaudo"
+      }
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "dev": true
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9Li/wFhm2D7DQ00VgdOY3Wb5E0+VKjxMgwcYT2m6Pj2kKUaFaKlMjHo6rjMMBTDQeA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
       }
     }
   }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -3,6 +3,9 @@
   "version": "1.0.0",
   "private": true,
   "dependencies": {},
+  "devDependencies": {
+    "ajv": "^8.17.1"
+  },
   "overrides": {
     "ajv": "^8.17.1"
   }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "neuralforge-frontend",
+  "version": "1.0.0",
+  "private": true,
+  "dependencies": {},
+  "overrides": {
+    "ajv": "^8.17.1"
+  }
+}


### PR DESCRIPTION
## Implementation for #-174570969

**Issue:** Fix 1 osv_ghsa_2g4f_4pwh_qvx6 security finding

### Approved Plan
I have gathered enough information. Here is the implementation plan:

---

### Approach

The security scanner found `ajv` 6.12.6 in `frontend/package-lock.json` (GHSA-2g4f-4pwh-qvx6 — Inefficient Regular Expression Complexity / ReDoS, CVSS 5.0). The current `main` branch has no `frontend/` directory; previous autopilot attempts created `frontend/package.json` and `frontend/package-lock.json` on branches but never merged them, and those versions had an incomplete fix (only an `overrides` entry in the root lockfile metadata, with no regenerated `node_modules/ajv` entry).

The fix is to create a proper `frontend/package.json` that declares an npm `overrides` field forcing `ajv` to `^8.17.1` (safe major upgrade beyond the vulnerable 6.x line), then run `npm install` to generate a clean `package-lock.json` that resolves any transitive `ajv` dependency to a version ≥ 6.13.0. Since there are no direct npm dependencies in this project, the lockfile will be minimal, but it must explicitly express the override constraint so future additions are protected.

---

### Files to Modify

| File | Action |
|---|---|
| `frontend/package.json` | Create |
| `frontend/package-lock.json` | Create (via `npm install`) |

---

### Implementation Steps

1. **Create `frontend/package.json`** with no direct dependencies but with an `overrides` field to force any transitive `ajv` usage to `^8.17.1`:

   ```json
   {
     "name": "neuralforge-frontend",
     "version": "1.0.0",
     "private": true,
     "dependencies": {},
     "overrides": {
       "ajv": "^8.17.1"
     }
   }
   ```

   Key points:
   - Use `"overrides"` (npm v7+ built-in mechanism, not `"resolutions"` which is yarn-specific)
   - `^8.17.1` is the latest safe major line; it fully avoids all known ajv 6.x vulnerabilities including GHSA-2g4f-4pwh-qvx6

2. **Generate `frontend/package-lock.json`** by running `npm install` inside `frontend/`:

   ```bash
   cd frontend
   npm install
   ```

   This will produce a `package-lock.j

### Files Changed
- `frontend/package-lock.json`
- `frontend/package.json`

---
*Created by NeuralWarden Autopilot (event-driven recovery)*