### PR TITLE
feat: implement #-31454400 — Fix 9 agent_sec_002 security findings

### DIFF
--- a/internal/llm/claude.go
+++ b/internal/llm/claude.go
@@ -3,6 +3,7 @@ package llm
 import (
 	"context"
 	"fmt"
+	"log/slog"
 
 	anthropic "github.com/anthropics/anthropic-sdk-go"
 	"github.com/anthropics/anthropic-sdk-go/option"
@@ -68,6 +69,8 @@ func (c *ClaudeBackend) Complete(ctx context.Context, req CompletionRequest) (Co
 	if req.Temperature > 0 {
 		params.Temperature = param.NewOpt(req.Temperature)
 	}
+
+	slog.Info("llm call", "backend", "claude", "agent", req.AgentName, "model", model)
 
 	resp, err := withRetry(ctx, DefaultRetryConfig, func() (*anthropic.Message, error) {
 		return c.client.Messages.New(ctx, params)

--- a/internal/llm/claude.go
+++ b/internal/llm/claude.go
@@ -70,7 +70,7 @@ func (c *ClaudeBackend) Complete(ctx context.Context, req CompletionRequest) (Co
 		params.Temperature = param.NewOpt(req.Temperature)
 	}
 
-	slog.Info("llm call", "backend", "claude", "agent", req.AgentName, "model", model)
+	slog.Info("llm call", "backend", "claude", "agent", sanitizeAgentName(req.AgentName), "model", model, "data_classification", "non-pii")
 
 	resp, err := withRetry(ctx, DefaultRetryConfig, func() (*anthropic.Message, error) {
 		return c.client.Messages.New(ctx, params)

--- a/internal/llm/llm.go
+++ b/internal/llm/llm.go
@@ -24,6 +24,24 @@ type CompletionRequest struct {
 	Temperature float64   `json:"temperature"`
 }
 
+// allowedAgentNames is the allowlist of valid pipeline stage names for audit logging.
+// Values not on this list are replaced with "unknown" to prevent inadvertent PII
+// leakage if AgentName is ever populated from external input. Prompt content is
+// intentionally excluded from log entries to prevent PHI/PII leakage.
+var allowedAgentNames = map[string]bool{
+	"architect": true,
+	"security":  true,
+	"review":    true,
+}
+
+// sanitizeAgentName returns name if it is on the allowlist, otherwise "unknown".
+func sanitizeAgentName(name string) string {
+	if allowedAgentNames[name] {
+		return name
+	}
+	return "unknown"
+}
+
 type CompletionResponse struct {
 	Content      string `json:"content"`
 	Model        string `json:"model"`

--- a/internal/llm/llm.go
+++ b/internal/llm/llm.go
@@ -16,6 +16,7 @@ type Message struct {
 }
 
 type CompletionRequest struct {
+	AgentName   string    `json:"agent_name,omitempty"`
 	System      string    `json:"system"`
 	Messages    []Message `json:"messages"`
 	Model       string    `json:"model"`

--- a/internal/llm/openai.go
+++ b/internal/llm/openai.go
@@ -62,7 +62,7 @@ func (o *OpenAIBackend) Complete(ctx context.Context, req CompletionRequest) (Co
 		params.Temperature = param.NewOpt(req.Temperature)
 	}
 
-	slog.Info("llm call", "backend", "openai", "agent", req.AgentName, "model", model)
+	slog.Info("llm call", "backend", "openai", "agent", sanitizeAgentName(req.AgentName), "model", model, "data_classification", "non-pii")
 
 	resp, err := withRetry(ctx, DefaultRetryConfig, func() (*openai.ChatCompletion, error) {
 		return o.client.Chat.Completions.New(ctx, params)

--- a/internal/llm/openai.go
+++ b/internal/llm/openai.go
@@ -3,6 +3,7 @@ package llm
 import (
 	"context"
 	"fmt"
+	"log/slog"
 
 	openai "github.com/openai/openai-go"
 	"github.com/openai/openai-go/option"
@@ -60,6 +61,8 @@ func (o *OpenAIBackend) Complete(ctx context.Context, req CompletionRequest) (Co
 	if req.Temperature > 0 {
 		params.Temperature = param.NewOpt(req.Temperature)
 	}
+
+	slog.Info("llm call", "backend", "openai", "agent", req.AgentName, "model", model)
 
 	resp, err := withRetry(ctx, DefaultRetryConfig, func() (*openai.ChatCompletion, error) {
 		return o.client.Chat.Completions.New(ctx, params)

--- a/internal/pipeline/architect.go
+++ b/internal/pipeline/architect.go
@@ -29,7 +29,8 @@ func (s *ArchitectStage) Run(ctx context.Context, state *PipelineState) (StageRe
 	)
 
 	resp, err := s.llm.Complete(ctx, llm.CompletionRequest{
-		System: "You are a software architect creating implementation plans.",
+		AgentName: "architect",
+		System:    "You are a software architect creating implementation plans.",
 		Messages: []llm.Message{
 			{Role: llm.RoleUser, Content: prompt},
 		},

--- a/internal/pipeline/review.go
+++ b/internal/pipeline/review.go
@@ -53,7 +53,8 @@ func (s *ReviewStage) Run(ctx context.Context, state *PipelineState) (StageResul
 	)
 
 	resp, err := s.llm.Complete(ctx, llm.CompletionRequest{
-		System: "You are a code reviewer. Start your response with APPROVE or REQUEST_CHANGES.",
+		AgentName: "review",
+		System:    "You are a code reviewer. Start your response with APPROVE or REQUEST_CHANGES.",
 		Messages: []llm.Message{
 			{Role: llm.RoleUser, Content: prompt},
 		},

--- a/internal/pipeline/security.go
+++ b/internal/pipeline/security.go
@@ -36,7 +36,8 @@ func (s *SecurityStage) Run(ctx context.Context, state *PipelineState) (StageRes
 	)
 
 	resp, err := s.llm.Complete(ctx, llm.CompletionRequest{
-		System: "You are a security reviewer analyzing implementation plans for vulnerabilities.",
+		AgentName: "security",
+		System:    "You are a security reviewer analyzing implementation plans for vulnerabilities.",
 		Messages: []llm.Message{
 			{Role: llm.RoleUser, Content: prompt},
 		},


### PR DESCRIPTION
## Implementation for #-31454400

**Issue:** Fix 9 agent_sec_002 security findings

### Approved Plan
Now I have enough context. Let me produce the implementation plan.

---

### Approach

The 9 `agent_sec_002` findings all share the same root cause: calls to an LLM factory/constructor omit an `agent_name` parameter, making LLM calls unattributable in audit logs. The referenced Python files (`api/llm_sast_scanner.py`, `api/autopilot/review_rules.py`, `pipeline/config.py`, `pipeline/llm_factory.py`) do not exist in this Go repository — they belong to a companion Python service scanned under job `repo:e47b27f`.

Since this is a Go codebase, the equivalent fix maps as follows:
- Add an `AgentName` field to `CompletionRequest` (the Go equivalent of the `agent_name=` kwarg)
- Log `AgentName` at the LLM backend level on every call (satisfies audit attribution)
- Update each pipeline stage's `Complete` call to populate `AgentName` with its stage name

This is a narrow, additive change: no new abstractions, no new config systems — just one field and structured log entries.

---

### Files to Modify

| File | Change |
|---|---|
| `internal/llm/llm.go` | Add `AgentName string` field to `CompletionRequest` |
| `internal/llm/claude.go` | Log `AgentName` via `slog` before each API call |
| `internal/llm/openai.go` | Log `AgentName` via `slog` before each API call |
| `internal/pipeline/architect.go` | Pass `AgentName: "architect"` in `CompletionRequest` |
| `internal/pipeline/security.go` | Pass `AgentName: "security"` in `CompletionRequest` |
| `internal/pipeline/review.go` | Pass `AgentName: "review"` in `CompletionRequest` |

---

### Implementation Steps

**Step 1 — `internal/llm/llm.go`: Add `AgentName` to `CompletionRequest`**

```go
type CompletionRequest struct {
    AgentName   string    `json:"agent_name,omitempty"` // add this field
    System      string    `json:"system"`
    Messages    []Message `json:"messages"`
    Model       string    `json:"model"`
    MaxTokens   int       `json:"max_tokens"`
    Temperature float64   `json:"temperature"`
}
```

**Step 2 — `

### Files Changed
- `internal/llm/claude.go`
- `internal/llm/llm.go`
- `internal/llm/openai.go`
- `internal/pipeline/architect.go`
- `internal/pipeline/review.go`
- `internal/pipeline/security.go`

---
*Created by NeuralWarden Autopilot (event-driven recovery)*