### PR TITLE
feat: implement #-884494371 — Fix 50 arch_005 security findings

### DIFF
--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -1,0 +1,122 @@
+package app
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/mandadapu/neuralforge/internal/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newTestApp creates an App with an in-memory SQLite store for testing handleEvent.
+func newTestApp(t *testing.T) *App {
+	t.Helper()
+	s, err := store.NewSQLiteStore(":memory:")
+	require.NoError(t, err)
+	require.NoError(t, s.Migrate(context.Background()))
+	t.Cleanup(func() { s.Close() })
+	return &App{store: s}
+}
+
+func issueLabeledPayload(t *testing.T, label string, issueNum int, issueTitle, repoFullName string) []byte {
+	t.Helper()
+	payload := map[string]any{
+		"action": "labeled",
+		"label":  map[string]any{"name": label},
+		"issue": map[string]any{
+			"number": issueNum,
+			"title":  issueTitle,
+			"body":   "",
+			"user":   map[string]any{"login": "author"},
+			"labels": []any{},
+		},
+		"repository": map[string]any{
+			"full_name":      repoFullName,
+			"default_branch": "main",
+			"clone_url":      "https://github.com/" + repoFullName + ".git",
+		},
+	}
+	b, err := json.Marshal(payload)
+	require.NoError(t, err)
+	return b
+}
+
+func TestHandleEvent_IssueLabeledNeuralforge(t *testing.T) {
+	a := newTestApp(t)
+
+	payload := issueLabeledPayload(t, "neuralforge", 42, "Fix the bug", "owner/repo")
+	a.handleEvent("issues", payload)
+
+	ctx := context.Background()
+	job, err := a.store.GetJobByIssue(ctx, "owner/repo", 42)
+	require.NoError(t, err)
+	require.NotNil(t, job)
+	assert.Equal(t, "owner/repo#42", job.ID)
+	assert.Equal(t, store.JobQueued, job.Status)
+	assert.Equal(t, "Fix the bug", job.IssueTitle)
+}
+
+func TestHandleEvent_IssueLabeledOtherLabel(t *testing.T) {
+	a := newTestApp(t)
+
+	payload := issueLabeledPayload(t, "bug", 7, "Some issue", "owner/repo")
+	a.handleEvent("issues", payload)
+
+	ctx := context.Background()
+	job, err := a.store.GetJobByIssue(ctx, "owner/repo", 7)
+	require.NoError(t, err)
+	assert.Nil(t, job, "no job should be created for non-neuralforge labels")
+}
+
+func TestHandleEvent_UnsupportedEventType(t *testing.T) {
+	a := newTestApp(t)
+
+	// "push" events are not handled — should return without panicking
+	a.handleEvent("push", []byte(`{"ref":"refs/heads/main"}`))
+
+	ctx := context.Background()
+	jobs, err := a.store.ListPendingJobs(ctx, 10)
+	require.NoError(t, err)
+	assert.Empty(t, jobs)
+}
+
+func TestHandleEvent_MalformedPayload(t *testing.T) {
+	a := newTestApp(t)
+
+	// Malformed JSON should not panic
+	assert.NotPanics(t, func() {
+		a.handleEvent("issues", []byte(`{invalid json`))
+	})
+}
+
+func TestHandleEvent_IssueNotLabeled(t *testing.T) {
+	a := newTestApp(t)
+
+	// action != "labeled" — no job should be created
+	payload := map[string]any{
+		"action": "opened",
+		"issue": map[string]any{
+			"number": 5,
+			"title":  "New issue",
+			"body":   "",
+			"user":   map[string]any{"login": "someone"},
+			"labels": []any{},
+		},
+		"repository": map[string]any{
+			"full_name":      "owner/repo",
+			"default_branch": "main",
+			"clone_url":      "https://github.com/owner/repo.git",
+		},
+	}
+	b, err := json.Marshal(payload)
+	require.NoError(t, err)
+
+	a.handleEvent("issues", b)
+
+	ctx := context.Background()
+	job, err := a.store.GetJobByIssue(ctx, "owner/repo", 5)
+	require.NoError(t, err)
+	assert.Nil(t, job)
+}

--- a/internal/github/client_test.go
+++ b/internal/github/client_test.go
@@ -1,0 +1,199 @@
+package github
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// testTransport redirects all HTTP requests to the given test server,
+// preserving path and query but replacing scheme and host.
+type testTransport struct {
+	serverURL string
+}
+
+func (t *testTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	base, err := url.Parse(t.serverURL)
+	if err != nil {
+		return nil, err
+	}
+	newReq := req.Clone(req.Context())
+	newReq.URL.Scheme = base.Scheme
+	newReq.URL.Host = base.Host
+	return http.DefaultTransport.RoundTrip(newReq)
+}
+
+func newTestClient(server *httptest.Server) *Client {
+	httpClient := &http.Client{Transport: &testTransport{serverURL: server.URL}}
+	return NewClient(httpClient)
+}
+
+func TestCreatePR_Success(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		json.NewEncoder(w).Encode(map[string]any{
+			"number":   42,
+			"html_url": "https://github.com/owner/repo/pull/42",
+		})
+	}))
+	defer server.Close()
+
+	c := newTestClient(server)
+	num, htmlURL, err := c.CreatePR(context.Background(), "owner", "repo", "title", "body", "head", "main")
+
+	require.NoError(t, err)
+	assert.Equal(t, 42, num)
+	assert.Equal(t, "https://github.com/owner/repo/pull/42", htmlURL)
+}
+
+func TestCreatePR_Error(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnprocessableEntity)
+		w.Write([]byte(`{"message":"Validation Failed"}`))
+	}))
+	defer server.Close()
+
+	c := newTestClient(server)
+	_, _, err := c.CreatePR(context.Background(), "owner", "repo", "title", "body", "head", "main")
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "create PR")
+}
+
+func TestCommentOnIssue_Success(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		json.NewEncoder(w).Encode(map[string]any{"id": 1, "body": "test"})
+	}))
+	defer server.Close()
+
+	c := newTestClient(server)
+	err := c.CommentOnIssue(context.Background(), "owner", "repo", 1, "hello")
+
+	require.NoError(t, err)
+}
+
+func TestCommentOnIssue_Error(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		w.Write([]byte(`{"message":"Not Found"}`))
+	}))
+	defer server.Close()
+
+	c := newTestClient(server)
+	err := c.CommentOnIssue(context.Background(), "owner", "repo", 999, "hi")
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "comment on issue")
+}
+
+func TestMergePR_Success(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPut, r.Method)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(map[string]any{"sha": "abc123", "merged": true})
+	}))
+	defer server.Close()
+
+	c := newTestClient(server)
+	err := c.MergePR(context.Background(), "owner", "repo", 42, "merge commit")
+
+	require.NoError(t, err)
+}
+
+func TestMergePR_Error(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusMethodNotAllowed)
+		w.Write([]byte(`{"message":"Method Not Allowed"}`))
+	}))
+	defer server.Close()
+
+	c := newTestClient(server)
+	err := c.MergePR(context.Background(), "owner", "repo", 42, "msg")
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "merge PR")
+}
+
+func TestCreateReview_Success(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(map[string]any{"id": 1, "state": "APPROVED"})
+	}))
+	defer server.Close()
+
+	c := newTestClient(server)
+	err := c.CreateReview(context.Background(), "owner", "repo", 42, "looks good", "APPROVE")
+
+	require.NoError(t, err)
+}
+
+func TestGetFileContent_Success(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		// "hello world" base64-encoded
+		json.NewEncoder(w).Encode(map[string]any{
+			"type":     "file",
+			"encoding": "base64",
+			"content":  "aGVsbG8gd29ybGQ=\n",
+			"name":     "test.txt",
+			"path":     "path/to/test.txt",
+			"sha":      "abc123",
+			"size":     11,
+		})
+	}))
+	defer server.Close()
+
+	c := newTestClient(server)
+	content, err := c.GetFileContent(context.Background(), "owner", "repo", "path/to/test.txt", "main")
+
+	require.NoError(t, err)
+	assert.Equal(t, "hello world", content)
+}
+
+func TestGetFileContent_DirectoryPath(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Return a JSON array (directory listing) — go-github sets fileContent=nil
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode([]map[string]any{
+			{"type": "file", "name": "a.txt", "path": "dir/a.txt", "sha": "x"},
+		})
+	}))
+	defer server.Close()
+
+	c := newTestClient(server)
+	_, err := c.GetFileContent(context.Background(), "owner", "repo", "dir", "main")
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "directory")
+}
+
+func TestGetFileContent_Error(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		w.Write([]byte(`{"message":"Not Found"}`))
+	}))
+	defer server.Close()
+
+	c := newTestClient(server)
+	_, err := c.GetFileContent(context.Background(), "owner", "repo", "missing.txt", "main")
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "get file content")
+}

--- a/internal/pipeline/architect_test.go
+++ b/internal/pipeline/architect_test.go
@@ -1,0 +1,55 @@
+package pipeline
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestArchitectStage_Name(t *testing.T) {
+	s := NewArchitectStage(&mockLLM{})
+	assert.Equal(t, "architect", s.Name())
+}
+
+func TestArchitectStage_Success(t *testing.T) {
+	llmMock := &mockLLM{content: "Step 1: modify foo.go", cost: 0.10}
+	s := NewArchitectStage(llmMock)
+	state := &PipelineState{
+		Issue: GitHubIssue{Number: 1, Title: "Fix bug", Body: "It's broken"},
+	}
+
+	result, err := s.Run(context.Background(), state)
+
+	require.NoError(t, err)
+	assert.Equal(t, StatusPassed, result.Status)
+	assert.Equal(t, "Step 1: modify foo.go", state.Plan)
+	assert.InDelta(t, 0.10, state.Cost, 0.001)
+	assert.Contains(t, result.Output, "plan")
+}
+
+func TestArchitectStage_CostAccumulates(t *testing.T) {
+	llmMock := &mockLLM{content: "plan", cost: 0.20}
+	s := NewArchitectStage(llmMock)
+	state := &PipelineState{
+		Issue: GitHubIssue{Number: 1, Title: "T"},
+		Cost:  0.05, // pre-existing cost
+	}
+
+	_, err := s.Run(context.Background(), state)
+	require.NoError(t, err)
+	assert.InDelta(t, 0.25, state.Cost, 0.001)
+}
+
+func TestArchitectStage_LLMError(t *testing.T) {
+	llmMock := &mockLLM{err: assert.AnError}
+	s := NewArchitectStage(llmMock)
+	state := &PipelineState{
+		Issue: GitHubIssue{Number: 1, Title: "Test"},
+	}
+
+	_, err := s.Run(context.Background(), state)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "architect llm call")
+}

--- a/internal/pipeline/compliance_test.go
+++ b/internal/pipeline/compliance_test.go
@@ -1,0 +1,146 @@
+package pipeline
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// initComplianceRepo creates a minimal git repo on a feature branch with one
+// added file, returning the repo dir and the default branch name.
+func initComplianceRepo(t *testing.T) (dir, defaultBranch string) {
+	t.Helper()
+
+	_, err := exec.LookPath("git")
+	if err != nil {
+		t.Skip("git binary not available")
+	}
+
+	dir = t.TempDir()
+	cmds := [][]string{
+		{"git", "init", dir},
+		{"git", "-C", dir, "config", "user.email", "test@test.com"},
+		{"git", "-C", dir, "config", "user.name", "Test"},
+	}
+	for _, c := range cmds {
+		require.NoError(t, exec.Command(c[0], c[1:]...).Run())
+	}
+
+	// Initial commit on the default branch.
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "README.md"), []byte("# test"), 0644))
+	require.NoError(t, exec.Command("git", "-C", dir, "add", ".").Run())
+	require.NoError(t, exec.Command("git", "-C", dir, "commit", "-m", "init").Run())
+
+	out, err := exec.Command("git", "-C", dir, "rev-parse", "--abbrev-ref", "HEAD").Output()
+	require.NoError(t, err)
+	defaultBranch = strings.TrimSpace(string(out))
+
+	// Create a feature branch with one added file.
+	require.NoError(t, exec.Command("git", "-C", dir, "checkout", "-b", "feature").Run())
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "new.txt"), []byte("line1\n"), 0644))
+	require.NoError(t, exec.Command("git", "-C", dir, "add", ".").Run())
+	require.NoError(t, exec.Command("git", "-C", dir, "commit", "-m", "add new.txt").Run())
+
+	return dir, defaultBranch
+}
+
+func TestComplianceStage_Name(t *testing.T) {
+	s := NewComplianceStage(2000, 50)
+	assert.Equal(t, "compliance", s.Name())
+}
+
+func TestComplianceStage_SkipNoPath(t *testing.T) {
+	s := NewComplianceStage(2000, 50)
+	state := &PipelineState{Repo: RepoContext{LocalPath: ""}}
+
+	result, err := s.Run(context.Background(), state)
+
+	require.NoError(t, err)
+	assert.Equal(t, StatusSkipped, result.Status)
+}
+
+func TestComplianceStage_Pass(t *testing.T) {
+	dir, defaultBranch := initComplianceRepo(t)
+
+	s := NewComplianceStage(2000, 50)
+	state := &PipelineState{
+		Repo: RepoContext{LocalPath: dir, DefaultBranch: defaultBranch},
+	}
+
+	result, err := s.Run(context.Background(), state)
+
+	require.NoError(t, err)
+	assert.Equal(t, StatusPassed, result.Status)
+	require.NotNil(t, state.Compliance)
+	assert.True(t, state.Compliance.Passed)
+	assert.Equal(t, 1, state.Compliance.FilesChanged)
+}
+
+func TestComplianceStage_TooManyFiles(t *testing.T) {
+	_, err := exec.LookPath("git")
+	if err != nil {
+		t.Skip("git binary not available")
+	}
+
+	dir, defaultBranch := initComplianceRepo(t)
+
+	// Add more files on the feature branch.
+	for i := 0; i < 5; i++ {
+		name := filepath.Join(dir, "extra"+string(rune('a'+i))+".txt")
+		require.NoError(t, os.WriteFile(name, []byte("x\n"), 0644))
+	}
+	require.NoError(t, exec.Command("git", "-C", dir, "add", ".").Run())
+	require.NoError(t, exec.Command("git", "-C", dir, "commit", "-m", "add extras").Run())
+
+	// Limit to 3 files.
+	s := NewComplianceStage(2000, 3)
+	state := &PipelineState{
+		Repo: RepoContext{LocalPath: dir, DefaultBranch: defaultBranch},
+	}
+
+	result, err := s.Run(context.Background(), state)
+
+	require.NoError(t, err)
+	assert.Equal(t, StatusFailed, result.Status)
+	require.NotNil(t, state.Compliance)
+	assert.False(t, state.Compliance.Passed)
+	assert.NotEmpty(t, state.Compliance.Violations)
+}
+
+func TestComplianceStage_TooManyLines(t *testing.T) {
+	_, err := exec.LookPath("git")
+	if err != nil {
+		t.Skip("git binary not available")
+	}
+
+	dir, defaultBranch := initComplianceRepo(t)
+
+	// Write a file with many lines on the feature branch.
+	var sb strings.Builder
+	for i := 0; i < 20; i++ {
+		sb.WriteString("line\n")
+	}
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "big.txt"), []byte(sb.String()), 0644))
+	require.NoError(t, exec.Command("git", "-C", dir, "add", ".").Run())
+	require.NoError(t, exec.Command("git", "-C", dir, "commit", "-m", "add big file").Run())
+
+	// Limit to 5 diff lines.
+	s := NewComplianceStage(5, 50)
+	state := &PipelineState{
+		Repo: RepoContext{LocalPath: dir, DefaultBranch: defaultBranch},
+	}
+
+	result, err := s.Run(context.Background(), state)
+
+	require.NoError(t, err)
+	assert.Equal(t, StatusFailed, result.Status)
+	require.NotNil(t, state.Compliance)
+	assert.False(t, state.Compliance.Passed)
+	assert.NotEmpty(t, state.Compliance.Violations)
+}

--- a/internal/pipeline/deploy_test.go
+++ b/internal/pipeline/deploy_test.go
@@ -1,0 +1,42 @@
+package pipeline
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDeployStage_Disabled(t *testing.T) {
+	s := NewDeployStage(false)
+	assert.Equal(t, "deploy", s.Name())
+
+	state := &PipelineState{}
+	result, err := s.Run(context.Background(), state)
+
+	require.NoError(t, err)
+	assert.Equal(t, StatusSkipped, result.Status)
+}
+
+func TestDeployStage_NotMerged(t *testing.T) {
+	s := NewDeployStage(true)
+	state := &PipelineState{Merged: false}
+
+	result, err := s.Run(context.Background(), state)
+
+	require.NoError(t, err)
+	assert.Equal(t, StatusSkipped, result.Status)
+	assert.Contains(t, result.Output, "not merged")
+}
+
+func TestDeployStage_Merged(t *testing.T) {
+	s := NewDeployStage(true)
+	state := &PipelineState{Merged: true}
+
+	result, err := s.Run(context.Background(), state)
+
+	require.NoError(t, err)
+	assert.Equal(t, StatusPassed, result.Status)
+	assert.Contains(t, result.Output, "Deploy triggered")
+}

--- a/internal/pipeline/execute_test.go
+++ b/internal/pipeline/execute_test.go
@@ -1,0 +1,81 @@
+package pipeline
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/mandadapu/neuralforge/internal/executor"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestExecuteStage_Name(t *testing.T) {
+	s := NewExecuteStage(&mockExecutor{}, time.Minute)
+	assert.Equal(t, "execute", s.Name())
+}
+
+func TestExecuteStage_Success(t *testing.T) {
+	exec := &mockExecutor{
+		result: executor.ExecutorResult{
+			Success:      true,
+			FilesChanged: []string{"foo.go", "bar.go"},
+		},
+	}
+	s := NewExecuteStage(exec, time.Minute)
+	state := &PipelineState{
+		JobID: "j1",
+		Issue: GitHubIssue{Number: 1},
+		Repo:  RepoContext{LocalPath: "/tmp/repo"},
+		Plan:  "do the thing",
+	}
+
+	result, err := s.Run(context.Background(), state)
+
+	require.NoError(t, err)
+	assert.Equal(t, StatusPassed, result.Status)
+	assert.Len(t, state.Changes, 2)
+	assert.Equal(t, "foo.go", state.Changes[0].Path)
+	assert.Equal(t, "modified", state.Changes[0].Action)
+}
+
+func TestExecuteStage_TimedOut(t *testing.T) {
+	exec := &mockExecutor{
+		result: executor.ExecutorResult{TimedOut: true},
+	}
+	s := NewExecuteStage(exec, time.Minute)
+	state := &PipelineState{Issue: GitHubIssue{Number: 1}}
+
+	result, err := s.Run(context.Background(), state)
+
+	require.NoError(t, err)
+	assert.Equal(t, StatusFailed, result.Status)
+	assert.Contains(t, result.Output, "timed out")
+}
+
+func TestExecuteStage_ExecutionFailed(t *testing.T) {
+	exec := &mockExecutor{
+		result: executor.ExecutorResult{
+			Success: false,
+			Stderr:  "compilation error",
+		},
+	}
+	s := NewExecuteStage(exec, time.Minute)
+	state := &PipelineState{Issue: GitHubIssue{Number: 1}}
+
+	result, err := s.Run(context.Background(), state)
+
+	require.NoError(t, err)
+	assert.Equal(t, StatusFailed, result.Status)
+	assert.Contains(t, result.Output, "compilation error")
+}
+
+func TestExecuteStage_ExecutorError(t *testing.T) {
+	exec := &mockExecutor{err: assert.AnError}
+	s := NewExecuteStage(exec, time.Minute)
+	state := &PipelineState{Issue: GitHubIssue{Number: 1}}
+
+	_, err := s.Run(context.Background(), state)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "executor run")
+}

--- a/internal/pipeline/merge_test.go
+++ b/internal/pipeline/merge_test.go
@@ -1,0 +1,93 @@
+package pipeline
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMergeStage_Name(t *testing.T) {
+	s := NewMergeStage(&mockGitHubClient{}, false)
+	assert.Equal(t, "merge", s.Name())
+}
+
+func TestMergeStage_AutoMergeDisabled(t *testing.T) {
+	s := NewMergeStage(&mockGitHubClient{}, false)
+	state := &PipelineState{PRNumber: 42}
+
+	result, err := s.Run(context.Background(), state)
+
+	require.NoError(t, err)
+	assert.Equal(t, StatusSkipped, result.Status)
+	assert.Contains(t, result.Output, "disabled")
+}
+
+func TestMergeStage_NoPR(t *testing.T) {
+	s := NewMergeStage(&mockGitHubClient{}, true)
+	state := &PipelineState{PRNumber: 0}
+
+	result, err := s.Run(context.Background(), state)
+
+	require.NoError(t, err)
+	assert.Equal(t, StatusSkipped, result.Status)
+	assert.Contains(t, result.Output, "No PR")
+}
+
+func TestMergeStage_ReviewRequestedChanges(t *testing.T) {
+	s := NewMergeStage(&mockGitHubClient{}, true)
+	state := &PipelineState{
+		PRNumber:    42,
+		ReviewNotes: "REQUEST_CHANGES: needs improvement",
+		Repo:        RepoContext{FullName: "owner/repo"},
+	}
+
+	result, err := s.Run(context.Background(), state)
+
+	require.NoError(t, err)
+	assert.Equal(t, StatusFailed, result.Status)
+	assert.Contains(t, result.Output, "merge blocked")
+}
+
+func TestMergeStage_InvalidRepoName(t *testing.T) {
+	s := NewMergeStage(&mockGitHubClient{}, true)
+	state := &PipelineState{
+		PRNumber: 42,
+		Repo:     RepoContext{FullName: "invalid"},
+	}
+
+	_, err := s.Run(context.Background(), state)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid repo name")
+}
+
+func TestMergeStage_Success(t *testing.T) {
+	s := NewMergeStage(&mockGitHubClient{}, true)
+	state := &PipelineState{
+		PRNumber: 42,
+		Issue:    GitHubIssue{Number: 1},
+		Repo:     RepoContext{FullName: "owner/repo"},
+	}
+
+	result, err := s.Run(context.Background(), state)
+
+	require.NoError(t, err)
+	assert.Equal(t, StatusPassed, result.Status)
+	assert.True(t, state.Merged)
+	assert.Contains(t, result.Output, "42")
+}
+
+func TestMergeStage_ClientError(t *testing.T) {
+	client := &mockGitHubClient{mergeErr: assert.AnError}
+	s := NewMergeStage(client, true)
+	state := &PipelineState{
+		PRNumber: 42,
+		Issue:    GitHubIssue{Number: 1},
+		Repo:     RepoContext{FullName: "owner/repo"},
+	}
+
+	_, err := s.Run(context.Background(), state)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "merge PR")
+}

--- a/internal/pipeline/pr_test.go
+++ b/internal/pipeline/pr_test.go
@@ -1,0 +1,81 @@
+package pipeline
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPRStage_Name(t *testing.T) {
+	s := NewPRStage(&mockGitHubClient{})
+	assert.Equal(t, "pr", s.Name())
+}
+
+func TestPRStage_Success(t *testing.T) {
+	client := &mockGitHubClient{
+		createPRNum: 42,
+		createPRURL: "https://github.com/owner/repo/pull/42",
+	}
+	s := NewPRStage(client)
+	state := &PipelineState{
+		Issue: GitHubIssue{Number: 1, Title: "Fix the bug"},
+		Repo: RepoContext{
+			FullName:      "owner/repo",
+			DefaultBranch: "main",
+		},
+		Plan: "Step 1: ...",
+	}
+
+	result, err := s.Run(context.Background(), state)
+
+	require.NoError(t, err)
+	assert.Equal(t, StatusPassed, result.Status)
+	assert.Equal(t, 42, state.PRNumber)
+	assert.Equal(t, "https://github.com/owner/repo/pull/42", state.PRURL)
+	assert.Contains(t, result.Output, "42")
+}
+
+func TestPRStage_TitleTruncated(t *testing.T) {
+	client := &mockGitHubClient{createPRNum: 1, createPRURL: "https://github.com/o/r/pull/1"}
+	s := NewPRStage(client)
+
+	longTitle := strings.Repeat("a", 100)
+	state := &PipelineState{
+		Issue: GitHubIssue{Number: 1, Title: longTitle},
+		Repo:  RepoContext{FullName: "owner/repo", DefaultBranch: "main"},
+	}
+
+	_, err := s.Run(context.Background(), state)
+	require.NoError(t, err)
+	// Title is formatted as "fix: #1 <title>" and truncated to 72 chars
+	// The test verifies no error, and the PR was created successfully.
+	assert.Equal(t, 1, state.PRNumber)
+}
+
+func TestPRStage_InvalidRepoName(t *testing.T) {
+	s := NewPRStage(&mockGitHubClient{})
+	state := &PipelineState{
+		Issue: GitHubIssue{Number: 1, Title: "Test"},
+		Repo:  RepoContext{FullName: "invalid-no-slash"},
+	}
+
+	_, err := s.Run(context.Background(), state)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid repo name")
+}
+
+func TestPRStage_ClientError(t *testing.T) {
+	client := &mockGitHubClient{createPRErr: assert.AnError}
+	s := NewPRStage(client)
+	state := &PipelineState{
+		Issue: GitHubIssue{Number: 1, Title: "Test"},
+		Repo:  RepoContext{FullName: "owner/repo", DefaultBranch: "main"},
+	}
+
+	_, err := s.Run(context.Background(), state)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "create PR")
+}

--- a/internal/pipeline/review_test.go
+++ b/internal/pipeline/review_test.go
@@ -1,0 +1,102 @@
+package pipeline
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestReviewStage_Name(t *testing.T) {
+	s := NewReviewStage(&mockLLM{}, &mockGitHubClient{})
+	assert.Equal(t, "review", s.Name())
+}
+
+func TestReviewStage_NoPR(t *testing.T) {
+	s := NewReviewStage(&mockLLM{content: "APPROVE looks good"}, &mockGitHubClient{})
+	state := &PipelineState{PRNumber: 0}
+
+	result, err := s.Run(context.Background(), state)
+
+	require.NoError(t, err)
+	assert.Equal(t, StatusSkipped, result.Status)
+	assert.Contains(t, result.Output, "No PR")
+}
+
+func TestReviewStage_Approve(t *testing.T) {
+	llmMock := &mockLLM{content: "APPROVE looks great", cost: 0.05}
+	client := &mockGitHubClient{}
+	s := NewReviewStage(llmMock, client)
+	state := &PipelineState{
+		PRNumber: 42,
+		Issue:    GitHubIssue{Number: 1, Title: "Fix bug"},
+		Repo:     RepoContext{FullName: "owner/repo"},
+	}
+
+	result, err := s.Run(context.Background(), state)
+
+	require.NoError(t, err)
+	assert.Equal(t, StatusPassed, result.Status)
+	assert.Equal(t, "APPROVE looks great", state.ReviewNotes)
+	assert.InDelta(t, 0.05, state.Cost, 0.001)
+}
+
+func TestReviewStage_RequestChanges(t *testing.T) {
+	llmMock := &mockLLM{content: "REQUEST_CHANGES missing tests"}
+	s := NewReviewStage(llmMock, &mockGitHubClient{})
+	state := &PipelineState{
+		PRNumber: 42,
+		Issue:    GitHubIssue{Number: 1},
+		Repo:     RepoContext{FullName: "owner/repo"},
+	}
+
+	result, err := s.Run(context.Background(), state)
+
+	require.NoError(t, err)
+	assert.Equal(t, StatusFailed, result.Status)
+	assert.Contains(t, result.Output, "REQUEST_CHANGES")
+}
+
+func TestReviewStage_LLMError(t *testing.T) {
+	llmMock := &mockLLM{err: assert.AnError}
+	s := NewReviewStage(llmMock, &mockGitHubClient{})
+	state := &PipelineState{
+		PRNumber: 42,
+		Issue:    GitHubIssue{Number: 1},
+		Repo:     RepoContext{FullName: "owner/repo"},
+	}
+
+	_, err := s.Run(context.Background(), state)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "review llm call")
+}
+
+func TestReviewStage_InvalidRepoName(t *testing.T) {
+	llmMock := &mockLLM{content: "APPROVE looks good"}
+	s := NewReviewStage(llmMock, &mockGitHubClient{})
+	state := &PipelineState{
+		PRNumber: 42,
+		Issue:    GitHubIssue{Number: 1},
+		Repo:     RepoContext{FullName: "bad"},
+	}
+
+	_, err := s.Run(context.Background(), state)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid repo name")
+}
+
+func TestReviewStage_CreateReviewError(t *testing.T) {
+	llmMock := &mockLLM{content: "APPROVE looks good"}
+	client := &mockGitHubClient{reviewErr: assert.AnError}
+	s := NewReviewStage(llmMock, client)
+	state := &PipelineState{
+		PRNumber: 42,
+		Issue:    GitHubIssue{Number: 1},
+		Repo:     RepoContext{FullName: "owner/repo"},
+	}
+
+	_, err := s.Run(context.Background(), state)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "post review")
+}

--- a/internal/pipeline/security_test.go
+++ b/internal/pipeline/security_test.go
@@ -1,0 +1,52 @@
+package pipeline
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSecurityStage_Name(t *testing.T) {
+	s := NewSecurityStage(&mockLLM{})
+	assert.Equal(t, "security", s.Name())
+}
+
+func TestSecurityStage_SkipEmptyPlan(t *testing.T) {
+	s := NewSecurityStage(&mockLLM{})
+	state := &PipelineState{Plan: ""}
+
+	result, err := s.Run(context.Background(), state)
+
+	require.NoError(t, err)
+	assert.Equal(t, StatusSkipped, result.Status)
+	assert.Equal(t, "", state.SecurityNotes)
+}
+
+func TestSecurityStage_Success(t *testing.T) {
+	llmMock := &mockLLM{content: "No critical issues found.", cost: 0.05}
+	s := NewSecurityStage(llmMock)
+	state := &PipelineState{
+		Plan: "Step 1: Add a new endpoint",
+		Repo: RepoContext{FullName: "owner/repo"},
+	}
+
+	result, err := s.Run(context.Background(), state)
+
+	require.NoError(t, err)
+	assert.Equal(t, StatusPassed, result.Status)
+	assert.Equal(t, "No critical issues found.", state.SecurityNotes)
+	assert.InDelta(t, 0.05, state.Cost, 0.001)
+	assert.Contains(t, result.Output, "Security review")
+}
+
+func TestSecurityStage_LLMError(t *testing.T) {
+	llmMock := &mockLLM{err: assert.AnError}
+	s := NewSecurityStage(llmMock)
+	state := &PipelineState{Plan: "do something"}
+
+	_, err := s.Run(context.Background(), state)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "security llm call")
+}

--- a/internal/pipeline/testhelpers_test.go
+++ b/internal/pipeline/testhelpers_test.go
@@ -1,0 +1,68 @@
+package pipeline
+
+import (
+	"context"
+
+	"github.com/mandadapu/neuralforge/internal/executor"
+	"github.com/mandadapu/neuralforge/internal/llm"
+)
+
+// mockLLM is a test double for llm.LLM.
+type mockLLM struct {
+	content string
+	cost    float64
+	err     error
+}
+
+func (m *mockLLM) Complete(_ context.Context, _ llm.CompletionRequest) (llm.CompletionResponse, error) {
+	if m.err != nil {
+		return llm.CompletionResponse{}, m.err
+	}
+	return llm.CompletionResponse{Content: m.content, Cost: m.cost}, nil
+}
+
+func (m *mockLLM) StreamComplete(_ context.Context, _ llm.CompletionRequest) (<-chan llm.StreamChunk, error) {
+	panic("not implemented")
+}
+
+func (m *mockLLM) Name() string { return "mock" }
+
+// mockGitHubClient is a test double for GitHubClient.
+type mockGitHubClient struct {
+	createPRNum int
+	createPRURL string
+	createPRErr error
+	mergeErr    error
+	reviewErr   error
+	commentErr  error
+}
+
+func (m *mockGitHubClient) CreatePR(_ context.Context, _, _, _, _, _, _ string) (int, string, error) {
+	return m.createPRNum, m.createPRURL, m.createPRErr
+}
+
+func (m *mockGitHubClient) MergePR(_ context.Context, _, _ string, _ int, _ string) error {
+	return m.mergeErr
+}
+
+func (m *mockGitHubClient) CreateReview(_ context.Context, _, _ string, _ int, _, _ string) error {
+	return m.reviewErr
+}
+
+func (m *mockGitHubClient) CommentOnIssue(_ context.Context, _, _ string, _ int, _ string) error {
+	return m.commentErr
+}
+
+// mockExecutor is a test double for executor.Executor.
+type mockExecutor struct {
+	result executor.ExecutorResult
+	err    error
+}
+
+func (m *mockExecutor) Run(_ context.Context, _ executor.ExecutorJob) (executor.ExecutorResult, error) {
+	return m.result, m.err
+}
+
+func (m *mockExecutor) Cleanup(_ context.Context, _ string) error { return nil }
+
+func (m *mockExecutor) Name() string { return "mock" }

--- a/internal/worker/worker_test.go
+++ b/internal/worker/worker_test.go
@@ -1,0 +1,101 @@
+package worker
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/mandadapu/neuralforge/internal/store"
+	"github.com/stretchr/testify/assert"
+)
+
+// workerMockStore is a separate mock from the one in pool_test.go,
+// tracking UpdateJobError and CompleteJob calls.
+type workerMockStore struct {
+	store.Store
+	updateCalled   bool
+	completeCalled bool
+}
+
+func (m *workerMockStore) UpdateJobError(_ context.Context, _ string, _ string) error {
+	m.updateCalled = true
+	return nil
+}
+
+func (m *workerMockStore) CompleteJob(_ context.Context, _ string, _ store.JobStatus) error {
+	m.completeCalled = true
+	return nil
+}
+
+func TestWorker_RunSuccess(t *testing.T) {
+	ms := &workerMockStore{}
+	jobs := make(chan store.Job, 1)
+	jobs <- store.Job{ID: "j1"}
+	close(jobs)
+
+	handler := func(_ context.Context, _ store.Job) error { return nil }
+	w := &Worker{id: 1, handler: handler, store: ms}
+	w.Run(context.Background(), jobs)
+
+	assert.True(t, ms.completeCalled)
+	assert.False(t, ms.updateCalled)
+}
+
+func TestWorker_RunJobFailure(t *testing.T) {
+	ms := &workerMockStore{}
+	jobs := make(chan store.Job, 1)
+	jobs <- store.Job{ID: "j1"}
+	close(jobs)
+
+	handler := func(_ context.Context, _ store.Job) error { return errors.New("boom") }
+	w := &Worker{id: 1, handler: handler, store: ms}
+	w.Run(context.Background(), jobs)
+
+	assert.True(t, ms.updateCalled)
+	assert.False(t, ms.completeCalled)
+}
+
+func TestWorker_RunExitsOnContextCancellation(t *testing.T) {
+	ms := &workerMockStore{}
+	jobs := make(chan store.Job) // never sends a job
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	done := make(chan struct{})
+	go func() {
+		w := &Worker{id: 1, handler: func(_ context.Context, _ store.Job) error { return nil }, store: ms}
+		w.Run(ctx, jobs)
+		close(done)
+	}()
+
+	cancel()
+	close(jobs) // unblock range
+
+	select {
+	case <-done:
+		// Run returned promptly
+	case <-time.After(time.Second):
+		t.Fatal("Run did not exit after context cancel and channel close")
+	}
+}
+
+func TestWorker_RunMultipleJobs(t *testing.T) {
+	ms := &workerMockStore{}
+	jobs := make(chan store.Job, 3)
+	jobs <- store.Job{ID: "j1"}
+	jobs <- store.Job{ID: "j2"}
+	jobs <- store.Job{ID: "j3"}
+	close(jobs)
+
+	var processed int
+	handler := func(_ context.Context, _ store.Job) error {
+		processed++
+		return nil
+	}
+	w := &Worker{id: 1, handler: handler, store: ms}
+	w.Run(context.Background(), jobs)
+
+	assert.Equal(t, 3, processed)
+	assert.True(t, ms.completeCalled)
+}


### PR DESCRIPTION
## Implementation for #-884494371

**Issue:** Fix 50 arch_005 security findings

### Approved Plan
Now I have enough context. Let me produce the implementation plan.

---

### Approach

**Critical finding:** The 50 arch_005 findings reference Python files (e.g., `api/autopilot/fix_handlers/base.py`) that **do not exist** in this repository. This is a pure Go codebase with no Python files. The scanner was run against a different service (a Python API layer) and the findings were filed against this repo in error.

However, this Go repo does have several source files with meaningful logic that lack corresponding test files — the spirit of arch_005 applies. The plan addresses both the mismatch and the real coverage gap in the Go codebase.

---

### Files to Modify

**New test files to create** (Go source files with non-trivial logic and no corresponding `_test.go`):

| New Test File | Covers |
|---|---|
| `internal/app/app_test.go` | `app.go` — `handleEvent()` |
| `internal/github/client_test.go` | `client.go` — all 5 API methods |
| `internal/pipeline/architect_test.go` | `architect.go` — `ArchitectStage.Run()` |
| `internal/pipeline/security_test.go` | `security.go` — `SecurityStage.Run()` |
| `internal/pipeline/execute_test.go` | `execute.go` — `ExecuteStage.Run()` |
| `internal/pipeline/pr_test.go` | `pr.go` — `PRStage.Run()` |
| `internal/pipeline/merge_test.go` | `merge.go` — `MergeStage.Run()` |
| `internal/pipeline/review_test.go` | `review.go` — `ReviewStage.Run()` |
| `internal/pipeline/deploy_test.go` — | `deploy.go` — `DeployStage.Run()` |
| `internal/pipeline/compliance_test.go` | `compliance.go` — `ComplianceStage.Run()` |
| `internal/worker/worker_test.go` | `worker.go` — `Worker.Run()` |

**Files excluded as untestable / interface-only:**
- `internal/pipeline/stage.go` — interfaces and constants only
- `internal/pipeline/state.go` — pure data structs
- `internal/store/store.go` — interface only
- `internal/executor/executor.go` — interface only
- `internal/llm/llm.go` — interface/types only
- `internal/llm/claude.go`, `internal/llm/openai.go` — thin w

### Files Changed
- `internal/app/app_test.go`
- `internal/github/client_test.go`
- `internal/pipeline/architect_test.go`
- `internal/pipeline/compliance_test.go`
- `internal/pipeline/deploy_test.go`
- `internal/pipeline/execute_test.go`
- `internal/pipeline/merge_test.go`
- `internal/pipeline/pr_test.go`
- `internal/pipeline/review_test.go`
- `internal/pipeline/security_test.go`
- `internal/pipeline/testhelpers_test.go`
- `internal/worker/worker_test.go`

---
*Created by NeuralWarden Autopilot Issues Agent*