### PR TITLE
feat: implement #-424532543 — Fix 25 llm_004 security findings

### DIFF
--- a/internal/llm/openai.go
+++ b/internal/llm/openai.go
@@ -53,9 +53,11 @@ func (o *OpenAIBackend) Complete(ctx context.Context, req CompletionRequest) (Co
 		Messages: msgs,
 	}
 
-	if req.MaxTokens > 0 {
-		params.MaxCompletionTokens = param.NewOpt(int64(req.MaxTokens))
+	maxTokens := int64(req.MaxTokens)
+	if maxTokens == 0 {
+		maxTokens = 4096
 	}
+	params.MaxCompletionTokens = param.NewOpt(maxTokens)
 
 	if req.Temperature > 0 {
 		params.Temperature = param.NewOpt(req.Temperature)

--- a/internal/llm/openai_test.go
+++ b/internal/llm/openai_test.go
@@ -1,0 +1,92 @@
+package llm
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	openai "github.com/openai/openai-go"
+	"github.com/openai/openai-go/option"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestOpenAIBackendMaxTokens(t *testing.T) {
+	tests := []struct {
+		name              string
+		requestMaxTokens  int
+		expectedMaxTokens float64
+	}{
+		{
+			name:              "zero MaxTokens defaults to 4096",
+			requestMaxTokens:  0,
+			expectedMaxTokens: 4096,
+		},
+		{
+			name:              "explicit MaxTokens preserved",
+			requestMaxTokens:  2048,
+			expectedMaxTokens: 2048,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var capturedBody []byte
+
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				capturedBody, _ = io.ReadAll(r.Body)
+				resp := map[string]interface{}{
+					"id":      "chatcmpl-test",
+					"object":  "chat.completion",
+					"created": 1234567890,
+					"model":   "gpt-4",
+					"choices": []map[string]interface{}{
+						{
+							"index": 0,
+							"message": map[string]interface{}{
+								"role":    "assistant",
+								"content": "test response",
+							},
+							"finish_reason": "stop",
+						},
+					},
+					"usage": map[string]interface{}{
+						"prompt_tokens":     10,
+						"completion_tokens": 5,
+						"total_tokens":      15,
+					},
+				}
+				w.Header().Set("Content-Type", "application/json")
+				_ = json.NewEncoder(w).Encode(resp)
+			}))
+			defer server.Close()
+
+			backend := &OpenAIBackend{
+				client: openai.NewClient(
+					option.WithAPIKey("test-key"),
+					option.WithBaseURL(server.URL),
+				),
+				model: "gpt-4",
+			}
+
+			req := CompletionRequest{
+				Messages:  []Message{{Role: RoleUser, Content: "hello"}},
+				MaxTokens: tt.requestMaxTokens,
+			}
+
+			_, err := backend.Complete(context.Background(), req)
+			require.NoError(t, err)
+
+			var body map[string]interface{}
+			err = json.Unmarshal(capturedBody, &body)
+			require.NoError(t, err)
+
+			actualMaxTokens, ok := body["max_completion_tokens"]
+			require.True(t, ok, "max_completion_tokens must be present in request body")
+			assert.Equal(t, tt.expectedMaxTokens, actualMaxTokens)
+		})
+	}
+}


### PR DESCRIPTION
## Implementation for #-424532543

**Issue:** Fix 25 llm_004 security findings

### Approved Plan
### Approach

The 25 security findings reference Python files (`api/`, `pipeline/*.py`) that **do not exist** in this Go codebase. This is a NeuralForge Go project, not the Python project where the scanner ran. The findings cannot be applied literally.

However, mapping the security intent ("always set `max_tokens` to prevent resource exhaustion") to the actual Go codebase reveals **one real gap**: `internal/llm/openai.go` does not apply a default `MaxTokens` when `req.MaxTokens == 0`, unlike `claude.go` which defaults to `4096`. All three call sites (`architect.go`, `review.go`, `security.go`) do set `MaxTokens` explicitly today, but the OpenAI backend provides no safety net if a future caller forgets.

---

### Files to Modify

| File | Change |
|---|---|
| `internal/llm/openai.go` | Add a default `MaxCompletionTokens` of 4096 when `req.MaxTokens == 0`, mirroring the Claude backend |

---

### Implementation Steps

**1. `internal/llm/openai.go` — lines 56–58**

Current code:
```go
if req.MaxTokens > 0 {
    params.MaxCompletionTokens = param.NewOpt(int64(req.MaxTokens))
}
```

Replace with a default-fallback pattern identical to `claude.go` (lines 35–38):
```go
maxTokens := int64(req.MaxTokens)
if maxTokens == 0 {
    maxTokens = 4096
}
params.MaxCompletionTokens = param.NewOpt(maxTokens)
```

This unconditionally sets `MaxCompletionTokens`, always capping output and preventing runaway token consumption regardless of whether callers set the field.

No other files require changes. All existing call sites already set `MaxTokens` explicitly; this change adds defense-in-depth at the backend layer.

---

### Testing

- Run `make test` — existing tests must pass.
- Add or extend a unit test in `internal/llm/` that constructs an `OpenAIBackend`, sends a `CompletionRequest` with `MaxTokens: 0`, and asserts that `MaxCompletionTokens` is set to `4096` in the outgoing params (using a mock or stub client).
- Verify that a request with an explicit `MaxTokens: 2048` still resul

### Files Changed
- `internal/llm/openai.go`
- `internal/llm/openai_test.go`

---
*Created by NeuralWarden Autopilot (event-driven recovery)*