### PR TITLE
feat: implement #-691264360 — Fix 10 agent_sec_001 security findings

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -175,9 +175,9 @@ func (a *App) buildJobHandler() worker.JobHandler {
 	var backend llm.LLM
 	switch a.cfg.LLM.DefaultProvider {
 	case "openai":
-		backend = llm.NewOpenAI(a.cfg.LLM.OpenAI.APIKey, a.cfg.LLM.OpenAI.Model)
+		backend = llm.NewAudited(llm.NewOpenAI(a.cfg.LLM.OpenAI.APIKey, a.cfg.LLM.OpenAI.Model))
 	default:
-		backend = llm.NewClaude(a.cfg.LLM.Claude.APIKey, a.cfg.LLM.Claude.Model)
+		backend = llm.NewAudited(llm.NewClaude(a.cfg.LLM.Claude.APIKey, a.cfg.LLM.Claude.Model))
 	}
 
 	// Create executor based on config.

--- a/internal/llm/audited.go
+++ b/internal/llm/audited.go
@@ -1,0 +1,61 @@
+package llm
+
+import (
+	"context"
+	"log/slog"
+	"time"
+)
+
+// AuditedLLM wraps any LLM backend and emits a structured audit log entry
+// for every completion call, recording provider, model, token usage, cost,
+// and latency. All LLM usage must flow through this wrapper so that the audit
+// trail is never bypassed.
+type AuditedLLM struct {
+	inner LLM
+}
+
+// NewAudited wraps inner in an AuditedLLM. All callers that previously
+// instantiated a backend directly (NewOpenAI, NewClaude) must instead call
+// NewAudited(NewOpenAI(...)) or NewAudited(NewClaude(...)).
+func NewAudited(inner LLM) *AuditedLLM {
+	if inner == nil {
+		panic("llm.NewAudited: inner must not be nil")
+	}
+	return &AuditedLLM{inner: inner}
+}
+
+func (a *AuditedLLM) Name() string { return a.inner.Name() }
+
+func (a *AuditedLLM) Complete(ctx context.Context, req CompletionRequest) (CompletionResponse, error) {
+	start := time.Now()
+	resp, err := a.inner.Complete(ctx, req)
+	latency := time.Since(start)
+
+	if err != nil {
+		slog.Info("llm.complete",
+			"provider", a.inner.Name(),
+			"model", req.Model,
+			"latency_ms", latency.Milliseconds(),
+			"error", err,
+		)
+		return resp, err
+	}
+
+	slog.Info("llm.complete",
+		"provider", a.inner.Name(),
+		"model", resp.Model,
+		"input_tokens", resp.InputTokens,
+		"output_tokens", resp.OutputTokens,
+		"cost_usd", resp.Cost,
+		"latency_ms", latency.Milliseconds(),
+	)
+	return resp, nil
+}
+
+func (a *AuditedLLM) StreamComplete(ctx context.Context, req CompletionRequest) (<-chan StreamChunk, error) {
+	slog.Info("llm.stream_complete",
+		"provider", a.inner.Name(),
+		"model", req.Model,
+	)
+	return a.inner.StreamComplete(ctx, req)
+}

--- a/internal/llm/audited_test.go
+++ b/internal/llm/audited_test.go
@@ -1,0 +1,127 @@
+package llm
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"log/slog"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type mockLLM struct {
+	name         string
+	completeResp CompletionResponse
+	completeErr  error
+	streamCh     chan StreamChunk
+	streamErr    error
+}
+
+func (m *mockLLM) Name() string { return m.name }
+
+func (m *mockLLM) Complete(_ context.Context, _ CompletionRequest) (CompletionResponse, error) {
+	return m.completeResp, m.completeErr
+}
+
+func (m *mockLLM) StreamComplete(_ context.Context, _ CompletionRequest) (<-chan StreamChunk, error) {
+	return m.streamCh, m.streamErr
+}
+
+func newTestLogger(buf *bytes.Buffer) *slog.Logger {
+	return slog.New(slog.NewJSONHandler(buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+}
+
+func TestAuditedLLM_Name(t *testing.T) {
+	inner := &mockLLM{name: "test-provider"}
+	a := NewAudited(inner)
+	assert.Equal(t, "test-provider", a.Name())
+}
+
+func TestAuditedLLM_Complete_Success(t *testing.T) {
+	var buf bytes.Buffer
+	slog.SetDefault(newTestLogger(&buf))
+
+	inner := &mockLLM{
+		name: "openai",
+		completeResp: CompletionResponse{
+			Content:      "hello",
+			Model:        "gpt-4",
+			InputTokens:  10,
+			OutputTokens: 5,
+			Cost:         0.0012,
+		},
+	}
+	a := NewAudited(inner)
+
+	req := CompletionRequest{Model: "gpt-4", MaxTokens: 100}
+	resp, err := a.Complete(context.Background(), req)
+
+	require.NoError(t, err)
+	assert.Equal(t, "hello", resp.Content)
+
+	log := buf.String()
+	assert.Contains(t, log, "llm.complete")
+	assert.Contains(t, log, "openai")
+	assert.Contains(t, log, "gpt-4")
+	assert.Contains(t, log, "input_tokens")
+	assert.Contains(t, log, "output_tokens")
+	assert.Contains(t, log, "cost_usd")
+	assert.Contains(t, log, "latency_ms")
+}
+
+func TestAuditedLLM_Complete_Error(t *testing.T) {
+	var buf bytes.Buffer
+	slog.SetDefault(newTestLogger(&buf))
+
+	inner := &mockLLM{
+		name:        "claude",
+		completeErr: errors.New("rate limit exceeded"),
+	}
+	a := NewAudited(inner)
+
+	req := CompletionRequest{Model: "claude-3", MaxTokens: 100}
+	_, err := a.Complete(context.Background(), req)
+
+	require.Error(t, err)
+	assert.EqualError(t, err, "rate limit exceeded")
+
+	log := buf.String()
+	assert.Contains(t, log, "llm.complete")
+	assert.Contains(t, log, "claude")
+	assert.Contains(t, log, "error")
+	assert.True(t, strings.Contains(log, "rate limit exceeded"))
+}
+
+func TestAuditedLLM_StreamComplete(t *testing.T) {
+	var buf bytes.Buffer
+	slog.SetDefault(newTestLogger(&buf))
+
+	ch := make(chan StreamChunk, 1)
+	ch <- StreamChunk{Content: "chunk", Done: true}
+	close(ch)
+
+	inner := &mockLLM{
+		name:     "openai",
+		streamCh: ch,
+	}
+	a := NewAudited(inner)
+
+	req := CompletionRequest{Model: "gpt-4", MaxTokens: 100}
+	resultCh, err := a.StreamComplete(context.Background(), req)
+
+	require.NoError(t, err)
+	assert.NotNil(t, resultCh)
+
+	log := buf.String()
+	assert.Contains(t, log, "llm.stream_complete")
+	assert.Contains(t, log, "openai")
+}
+
+func TestNewAudited_NilPanics(t *testing.T) {
+	assert.Panics(t, func() {
+		NewAudited(nil)
+	})
+}


### PR DESCRIPTION
## Implementation for #-691264360

**Issue:** Fix 10 agent_sec_001 security findings

### Approved Plan
---

### Approach

Create an `AuditedLLM` wrapper in the `internal/llm` package that implements the `LLM` interface, logs each invocation (provider, model, token counts, cost, latency) via `slog`, and is instantiated through a `NewAudited` factory function. Update `internal/app/app.go` to route all backend construction through this wrapper.

**Note on findings #3–10:** Files `api/secret_patterns.py`, `api/autopilot/workers/issue_agent.py`, `api/llm/vm_proxy_client.py`, `frontend/src/lib/docs-content.tsx`, and `pipeline/llm_factory.py` do **not exist** in this repository (it is Go-only). Those 8 findings are false positives from the scanner and require no code changes.

The 2 in-scope findings are:
- `internal/llm/openai.go:17` — `NewOpenAI` is a direct constructor with no audit trail
- `internal/app/app.go:178` — calls `NewOpenAI` / `NewClaude` directly, bypassing any audit controls

---

### Files to Modify

| File | Action |
|---|---|
| `internal/llm/audited.go` | **Create** — `AuditedLLM` struct + `NewAudited` factory |
| `internal/llm/audited_test.go` | **Create** — table-driven tests for the wrapper |
| `internal/app/app.go` | **Modify** — wrap both backends via `llm.NewAudited(...)` |

---

### Implementation Steps

**Step 1 — Create `internal/llm/audited.go`**

```go
package llm

import (
    "context"
    "log/slog"
    "time"
)

// AuditedLLM wraps any LLM backend and emits a structured audit log entry
// for every completion call, recording provider, model, token usage, cost,
// and latency. All LLM usage must flow through this wrapper so that the audit
// trail is never bypassed.
type AuditedLLM struct {
    inner LLM
}

// NewAudited wraps inner in an AuditedLLM. All callers that previously
// instantiated a backend directly (NewOpenAI, NewClaude) must instead call
// NewAudited(NewOpenAI(...)) or NewAudited(NewClaude(...)).
func NewAudited(inner LLM) *AuditedLLM {
    return &AuditedLLM{inner: inner}
}

func (a *AuditedLLM) Name() string { return a.inne

### Files Changed
- `internal/app/app.go`
- `internal/llm/audited.go`
- `internal/llm/audited_test.go`

---
*Created by NeuralWarden Autopilot (event-driven recovery)*