### PR TITLE
feat: implement #-919938870 — Fix 1 llm_010 security finding

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -64,8 +64,6 @@ func New(cfg config.Config) (*App, error) {
 	handler := a.buildJobHandler()
 	a.pool = worker.NewPool(cfg.Workers, s, handler)
 
-	// NOTE: model names, API keys, and LLM configuration are never exposed via HTTP.
-	// Any future endpoint that returns model metadata MUST require authentication.
 	mux := http.NewServeMux()
 	if a.ghApp != nil {
 		mux.Handle("/webhooks/github", a.ghApp.WebhookMiddleware(

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -64,6 +64,8 @@ func New(cfg config.Config) (*App, error) {
 	handler := a.buildJobHandler()
 	a.pool = worker.NewPool(cfg.Workers, s, handler)
 
+	// NOTE: model names, API keys, and LLM configuration are never exposed via HTTP.
+	// Any future endpoint that returns model metadata MUST require authentication.
 	mux := http.NewServeMux()
 	if a.ghApp != nil {
 		mux.Handle("/webhooks/github", a.ghApp.WebhookMiddleware(


### PR DESCRIPTION
## Implementation for #-919938870

**Issue:** Fix 1 llm_010 security finding

### Approved Plan
### Approach

The security scanner fired `llm_010` ("Restrict model access with authentication. Do not serve raw model files publicly.") against `api/schemas.py:562`. **This file does not exist in the NeuralForge codebase**, which is a pure Go project with no Python files. The finding is a false positive caused by a scanner misconfiguration or a path mismatch between the scanned target and this repository.

Analysis of the actual HTTP surface confirms the codebase is already compliant with `llm_010`'s intent:
- `/webhooks/github` — authenticated via HMAC-SHA256 signature (`webhook.go:55-65`) or GitHub App middleware (`app.go:68-80`)
- `/health` — returns only `{"status":"ok"}`, no model info
- No route exposes LLM model names, API keys, or model files

The LLM backend is constructed internally in `buildJobHandler` (`app.go:173-309`) from environment-sourced config values and is never serialized to any HTTP response.

### Files to Modify

None are required. The finding is a false positive; the codebase already satisfies the `llm_010` control.

If the team wants a defensive annotation to prevent future regressions (e.g., a developer inadvertently adding a `/models` or `/debug` endpoint without auth), a single comment in `internal/app/app.go` near the mux registration block would suffice.

### Implementation Steps

1. **Verify no Python files exist** — confirm `api/schemas.py` is absent. `find . -name "*.py"` should return nothing. Close the issue as a false positive (scanner matched the wrong repository or job).

2. **Optional hardening comment** — if the team wants a defensive note, add a comment in `internal/app/app.go` near the mux setup (line ~67) explaining that model configuration is intentionally never exposed via HTTP, so future endpoints that would expose model metadata must be protected with authentication before registration.

   ```go
   // NOTE: model names, API keys, and LLM configuration are never exposed via HTTP.
   // Any future endpoint that returns

### Files Changed
- `internal/app/app.go`

---
*Created by NeuralWarden Autopilot (event-driven recovery)*