### PR TITLE
feat: implement #-393343882 — Fix 1 osv_ghsa_hp87_p4gw_j4gq security finding

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -149,7 +149,6 @@ gopkg.in/inf.v0 v0.9.1 h1:73M5CoZyi3ZLMOyDlQh031Cx6N9NDJ2Vvfl76EDAgDc=
 gopkg.in/inf.v0 v0.9.1/go.mod h1:cWUDdTG/fYaXco+Dcufb5Vnc6Gp2YChqWtbxRZE0mXw=
 gopkg.in/yaml.v2 v2.2.8 h1:obN1ZagJSUGI0Ek/LBmuj4SNLPfIny3KsKFopxRdj10=
 gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
-gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 k8s.io/api v0.35.2 h1:tW7mWc2RpxW7HS4CoRXhtYHSzme1PN1UjGHJ1bdrtdw=


### PR DESCRIPTION
## Implementation for #-393343882

**Issue:** Fix 1 osv_ghsa_hp87_p4gw_j4gq security finding

### Approved Plan
---

### Approach

GHSA-HP87-P4GW-J4GQ is a denial-of-service vulnerability in `gopkg.in/yaml.v3` affecting versions before `v3.0.0-20220521103104-8f96da9f5d5e` (patched as stable `v3.0.1`). The project's `go.mod` already requires `gopkg.in/yaml.v3 v3.0.1` (the patched version), so no code is actually vulnerable. However, `go.sum` still contains a `/go.mod`-only hash for the old pre-release version `v3.0.0-20200313102051-9f266ea9e77c`, which is flagged by the OSV scanner because it appears in the lockfile. The fix is to run `go mod tidy` to remove the stale `go.sum` entry that references the vulnerable version.

---

### Files to Modify

| File | Change |
|------|--------|
| `go.sum` | Remove stale entry for `gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c` via `go mod tidy` |

`go.mod` does **not** need changes — `v3.0.1` is already the declared version.

---

### Implementation Steps

1. **Run `go mod tidy`** in the repository root.

   This command prunes `go.sum` of any hash entries that are no longer reachable in the current module graph. The entry:
   ```
   gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:...
   ```
   is a `/go.mod`-only hash that was written when Go resolved the module graph of a now-updated transitive dependency. After tidying, if no current dependency's `go.mod` still requires this old pre-release, the entry will be removed.

2. **Verify `go.sum` no longer references the vulnerable version** by confirming the `v3.0.0-20200313102051` line is absent.

3. **If the entry persists after `go mod tidy`** (because some indirect dep still pins it in its own go.mod), add an explicit minimum-version bump in `go.mod`:
   ```
   // in go.mod — already satisfied, but explicit for clarity:
   require gopkg.in/yaml.v3 v3.0.1
   ```
   This is already present, so Go's MVS will always select `v3.0.1` over the pre-release. In that edge case, the stale go.sum entry is technically harmless (unused by the build) but the scanner can be silenced

### Files Changed
- `go.sum`

---
*Created by NeuralWarden Autopilot (event-driven recovery)*