### PR TITLE
feat: implement #-942316936 — Fix 1 osv_go_2022_0603 security finding

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -149,7 +149,6 @@ gopkg.in/inf.v0 v0.9.1 h1:73M5CoZyi3ZLMOyDlQh031Cx6N9NDJ2Vvfl76EDAgDc=
 gopkg.in/inf.v0 v0.9.1/go.mod h1:cWUDdTG/fYaXco+Dcufb5Vnc6Gp2YChqWtbxRZE0mXw=
 gopkg.in/yaml.v2 v2.2.8 h1:obN1ZagJSUGI0Ek/LBmuj4SNLPfIny3KsKFopxRdj10=
 gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
-gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 k8s.io/api v0.35.2 h1:tW7mWc2RpxW7HS4CoRXhtYHSzme1PN1UjGHJ1bdrtdw=


### PR DESCRIPTION
## Implementation for #-942316936

**Issue:** Fix 1 osv_go_2022_0603 security finding

### Approved Plan
Now I have enough information to produce the plan.

---

### Approach

The security scanner flagged `gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c` appearing in `go.sum`. This is CVE-2022-28948 / GO-2022-0603 — a denial-of-service panic triggered by crafted YAML input. The project's `go.mod` already declares `gopkg.in/yaml.v3 v3.0.1` (the patched release) as a direct dependency, so no actual vulnerable code is compiled into the binary.

The scanner is flagging the `go.sum` entry `gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:...`, which is only a go.mod metadata hash (note the `/go.mod` suffix, no bare `h1:` line) kept by Go's module system to verify the module graph of transitive dependencies. The old version's source code is never downloaded.

The fix is to run `go mod tidy` to prune any stale `go.sum` entries that are no longer required by the current module graph.

---

### Files to Modify

| File | Change |
|---|---|
| `go.sum` | Updated automatically by `go mod tidy` — stale `v3.0.0-20200313102051-9f266ea9e77c/go.mod` entry removed if no transitive dep still references it |
| `go.mod` | No change required — `v3.0.1` is already declared |

---

### Implementation Steps

1. **Confirm current state** — `go.mod` line 11 already reads `gopkg.in/yaml.v3 v3.0.1`, which is the patched version. No version bump is needed.

2. **Run `go mod tidy`** in the repository root:
   ```
   go mod tidy
   ```
   This re-computes the minimal set of `go.sum` entries needed for the current module graph. If no remaining transitive dependency's `go.mod` references the old pre-release version, the line:
   ```
   gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
   ```
   will be removed from `go.sum`.

3. **If the entry persists after tidy** (because a transitive dep's `go.mod` still lists the old version), add a `go.mod` `require` override to assert the floor version explicitly. This is already satisfied b

### Files Changed
- `go.sum`

---
*Created by NeuralWarden Autopilot (event-driven recovery)*