### PR TITLE
feat: implement #-155025766 — Fix 10 agent_sec_001 security findings

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -171,14 +171,8 @@ func (a *App) handleEvent(eventType string, payload []byte) {
 // buildJobHandler creates the LLM backend and executor, then returns a handler
 // that clones the repo, builds pipeline state, and runs the pipeline engine.
 func (a *App) buildJobHandler() worker.JobHandler {
-	// Create LLM backend based on config.
-	var backend llm.LLM
-	switch a.cfg.LLM.DefaultProvider {
-	case "openai":
-		backend = llm.NewOpenAI(a.cfg.LLM.OpenAI.APIKey, a.cfg.LLM.OpenAI.Model)
-	default:
-		backend = llm.NewClaude(a.cfg.LLM.Claude.APIKey, a.cfg.LLM.Claude.Model)
-	}
+	// Create LLM backend based on config, wrapped with audit logging.
+	backend := llm.NewFromConfig(a.cfg.LLM)
 
 	// Create executor based on config.
 	var exec executor.Executor

--- a/internal/llm/audit.go
+++ b/internal/llm/audit.go
@@ -1,0 +1,42 @@
+package llm
+
+import (
+	"context"
+	"log/slog"
+	"time"
+)
+
+// AuditingLLM wraps any LLM and emits a structured audit log entry for
+// every completion request. This satisfies the agent_sec_001 requirement
+// that all LLM clients pass through an auditing layer.
+type AuditingLLM struct {
+	inner LLM
+}
+
+// WithAudit wraps inner with audit logging. Use this instead of
+// instantiating LLM backends directly.
+func WithAudit(inner LLM) LLM {
+	return &AuditingLLM{inner: inner}
+}
+
+func (a *AuditingLLM) Name() string { return a.inner.Name() }
+
+func (a *AuditingLLM) Complete(ctx context.Context, req CompletionRequest) (CompletionResponse, error) {
+	start := time.Now()
+	resp, err := a.inner.Complete(ctx, req)
+	slog.Info("llm_audit",
+		"provider", a.inner.Name(),
+		"model", resp.Model,
+		"input_tokens", resp.InputTokens,
+		"output_tokens", resp.OutputTokens,
+		"cost_usd", resp.Cost,
+		"latency_ms", time.Since(start).Milliseconds(),
+		"error", err,
+	)
+	return resp, err
+}
+
+func (a *AuditingLLM) StreamComplete(ctx context.Context, req CompletionRequest) (<-chan StreamChunk, error) {
+	slog.Info("llm_audit", "provider", a.inner.Name(), "operation", "stream_complete")
+	return a.inner.StreamComplete(ctx, req)
+}

--- a/internal/llm/audit.go
+++ b/internal/llm/audit.go
@@ -9,6 +9,10 @@ import (
 // AuditingLLM wraps any LLM and emits a structured audit log entry for
 // every completion request. This satisfies the agent_sec_001 requirement
 // that all LLM clients pass through an auditing layer.
+//
+// Data minimization: only operational metadata (provider, model, token counts,
+// cost, latency, error status) is logged. Request prompts and response content
+// are intentionally excluded to prevent accidental logging of PII/PHI/PCI data.
 type AuditingLLM struct {
 	inner LLM
 }
@@ -21,6 +25,15 @@ func WithAudit(inner LLM) LLM {
 
 func (a *AuditingLLM) Name() string { return a.inner.Name() }
 
+// sanitizeError returns a safe status string rather than the raw error to
+// prevent leakage of sensitive content that may appear in error messages.
+func sanitizeError(err error) string {
+	if err == nil {
+		return "none"
+	}
+	return "error"
+}
+
 func (a *AuditingLLM) Complete(ctx context.Context, req CompletionRequest) (CompletionResponse, error) {
 	start := time.Now()
 	resp, err := a.inner.Complete(ctx, req)
@@ -31,12 +44,19 @@ func (a *AuditingLLM) Complete(ctx context.Context, req CompletionRequest) (Comp
 		"output_tokens", resp.OutputTokens,
 		"cost_usd", resp.Cost,
 		"latency_ms", time.Since(start).Milliseconds(),
-		"error", err,
+		"error", sanitizeError(err),
 	)
 	return resp, err
 }
 
 func (a *AuditingLLM) StreamComplete(ctx context.Context, req CompletionRequest) (<-chan StreamChunk, error) {
-	slog.Info("llm_audit", "provider", a.inner.Name(), "operation", "stream_complete")
-	return a.inner.StreamComplete(ctx, req)
+	start := time.Now()
+	ch, err := a.inner.StreamComplete(ctx, req)
+	slog.Info("llm_audit",
+		"provider", a.inner.Name(),
+		"operation", "stream_complete",
+		"latency_ms", time.Since(start).Milliseconds(),
+		"error", sanitizeError(err),
+	)
+	return ch, err
 }

--- a/internal/llm/audit_test.go
+++ b/internal/llm/audit_test.go
@@ -1,0 +1,62 @@
+package llm
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"log/slog"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type stubLLM struct {
+	name string
+	resp CompletionResponse
+	err  error
+}
+
+func (s *stubLLM) Name() string { return s.name }
+
+func (s *stubLLM) Complete(_ context.Context, _ CompletionRequest) (CompletionResponse, error) {
+	return s.resp, s.err
+}
+
+func (s *stubLLM) StreamComplete(_ context.Context, _ CompletionRequest) (<-chan StreamChunk, error) {
+	return nil, nil
+}
+
+func TestAuditingLLM_Complete_LogsAuditEntry(t *testing.T) {
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewJSONHandler(&buf, nil))
+	slog.SetDefault(logger)
+
+	stub := &stubLLM{
+		name: "test-provider",
+		resp: CompletionResponse{
+			Content:      "hello",
+			Model:        "test-model",
+			InputTokens:  10,
+			OutputTokens: 5,
+			Cost:         0.001,
+		},
+	}
+
+	auditing := WithAudit(stub)
+	assert.Equal(t, "test-provider", auditing.Name())
+
+	resp, err := auditing.Complete(context.Background(), CompletionRequest{})
+	require.NoError(t, err)
+	assert.Equal(t, "hello", resp.Content)
+
+	var entry map[string]interface{}
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &entry))
+
+	assert.Equal(t, "llm_audit", entry["msg"])
+	assert.Equal(t, "test-provider", entry["provider"])
+	assert.Equal(t, "test-model", entry["model"])
+	assert.EqualValues(t, 10, entry["input_tokens"])
+	assert.EqualValues(t, 5, entry["output_tokens"])
+	assert.Contains(t, entry, "latency_ms")
+}

--- a/internal/llm/audit_test.go
+++ b/internal/llm/audit_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"log/slog"
 	"testing"
 
@@ -12,9 +13,10 @@ import (
 )
 
 type stubLLM struct {
-	name string
-	resp CompletionResponse
-	err  error
+	name    string
+	resp    CompletionResponse
+	err     error
+	streamErr error
 }
 
 func (s *stubLLM) Name() string { return s.name }
@@ -24,7 +26,7 @@ func (s *stubLLM) Complete(_ context.Context, _ CompletionRequest) (CompletionRe
 }
 
 func (s *stubLLM) StreamComplete(_ context.Context, _ CompletionRequest) (<-chan StreamChunk, error) {
-	return nil, nil
+	return nil, s.streamErr
 }
 
 func TestAuditingLLM_Complete_LogsAuditEntry(t *testing.T) {
@@ -59,4 +61,45 @@ func TestAuditingLLM_Complete_LogsAuditEntry(t *testing.T) {
 	assert.EqualValues(t, 10, entry["input_tokens"])
 	assert.EqualValues(t, 5, entry["output_tokens"])
 	assert.Contains(t, entry, "latency_ms")
+	// error field must be the sanitized status string, not the raw error value
+	assert.Equal(t, "none", entry["error"])
+}
+
+func TestAuditingLLM_Complete_SanitizesError(t *testing.T) {
+	var buf bytes.Buffer
+	slog.SetDefault(slog.New(slog.NewJSONHandler(&buf, nil)))
+
+	sensitiveMsg := "context: api_key=sk-secret123 user_id=42"
+	stub := &stubLLM{
+		name: "test-provider",
+		err:  errors.New(sensitiveMsg),
+	}
+
+	auditing := WithAudit(stub)
+	_, _ = auditing.Complete(context.Background(), CompletionRequest{})
+
+	var entry map[string]interface{}
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &entry))
+
+	// Raw error message must not appear in logs.
+	assert.Equal(t, "error", entry["error"])
+	assert.NotContains(t, buf.String(), sensitiveMsg)
+}
+
+func TestAuditingLLM_StreamComplete_LogsMetrics(t *testing.T) {
+	var buf bytes.Buffer
+	slog.SetDefault(slog.New(slog.NewJSONHandler(&buf, nil)))
+
+	stub := &stubLLM{name: "test-provider"}
+	auditing := WithAudit(stub)
+	_, _ = auditing.StreamComplete(context.Background(), CompletionRequest{})
+
+	var entry map[string]interface{}
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &entry))
+
+	assert.Equal(t, "llm_audit", entry["msg"])
+	assert.Equal(t, "test-provider", entry["provider"])
+	assert.Equal(t, "stream_complete", entry["operation"])
+	assert.Contains(t, entry, "latency_ms")
+	assert.Equal(t, "none", entry["error"])
 }

--- a/internal/llm/factory.go
+++ b/internal/llm/factory.go
@@ -1,0 +1,16 @@
+package llm
+
+import "github.com/mandadapu/neuralforge/internal/config"
+
+// NewFromConfig constructs the appropriate LLM backend from cfg and wraps it
+// with audit logging, satisfying the agent_sec_001 auditing factory requirement.
+func NewFromConfig(cfg config.LLMConfig) LLM {
+	var backend LLM
+	switch cfg.DefaultProvider {
+	case "openai":
+		backend = NewOpenAI(cfg.OpenAI.APIKey, cfg.OpenAI.Model)
+	default:
+		backend = NewClaude(cfg.Claude.APIKey, cfg.Claude.Model)
+	}
+	return WithAudit(backend)
+}


### PR DESCRIPTION
## Implementation for #-155025766

**Issue:** Fix 10 agent_sec_001 security findings

### Approved Plan
Now I have enough context to produce the plan. Let me note the key findings:

- **Findings #1–2** (`internal/app/app.go:178`, `internal/llm/openai.go:17`) are valid — they exist in this Go repository.
- **Findings #3–10** (`api/`, `frontend/`, `pipeline/`) reference paths that **do not exist** in this repository. This is a pure Go project with no Python or frontend code. These are false positives from a scanner run against a different codebase.

---

### Approach

Introduce an auditing wrapper type in the `internal/llm` package that implements the `LLM` interface and logs each LLM invocation (provider, model, token usage, cost, latency, and any error). Then add a single factory function `NewFromConfig` in the `llm` package that constructs the concrete backend and wraps it with the audit logger. Update `app.go` to call the factory instead of instantiating backends directly. Findings #3–10 reference non-existent paths and require no action.

---

### Files to Modify

| File | Action |
|---|---|
| `internal/llm/audit.go` | **Create** — auditing wrapper that implements `LLM` |
| `internal/llm/factory.go` | **Create** — `NewFromConfig` factory function |
| `internal/app/app.go` | **Modify** — replace direct `NewOpenAI`/`NewClaude` calls with factory call |

---

### Implementation Steps

**1. Create `internal/llm/audit.go`**

Add an `AuditingLLM` struct that wraps any `LLM` and logs each call via `log/slog`:

```go
package llm

import (
    "context"
    "log/slog"
    "time"
)

// AuditingLLM wraps any LLM and emits a structured audit log entry for
// every completion request. This satisfies the agent_sec_001 requirement
// that all LLM clients pass through an auditing layer.
type AuditingLLM struct {
    inner LLM
}

// WithAudit wraps inner with audit logging. Use this instead of
// instantiating LLM backends directly.
func WithAudit(inner LLM) LLM {
    return &AuditingLLM{inner: inner}
}

func (a *AuditingLLM) Name() string { return a.inner.Name() }

func (a *Auditi

### Files Changed
- `internal/app/app.go`
- `internal/llm/audit.go`
- `internal/llm/audit_test.go`
- `internal/llm/factory.go`

---
*Created by NeuralWarden Autopilot (event-driven recovery)*