### PR TITLE
feat: implement #-991027744 — Fix 12 agent_sec_003 security findings

### DIFF
--- a/internal/pipeline/architect.go
+++ b/internal/pipeline/architect.go
@@ -29,6 +29,8 @@ func (s *ArchitectStage) Run(ctx context.Context, state *PipelineState) (StageRe
 	)
 
 	resp, err := s.llm.Complete(ctx, llm.CompletionRequest{
+		// SECURITY: static trusted system prompt — no untrusted data interpolated here.
+		// Untrusted content (issue body, codebase context) is passed in the user message only.
 		System: "You are a software architect creating implementation plans.",
 		Messages: []llm.Message{
 			{Role: llm.RoleUser, Content: prompt},

--- a/internal/pipeline/review.go
+++ b/internal/pipeline/review.go
@@ -53,6 +53,8 @@ func (s *ReviewStage) Run(ctx context.Context, state *PipelineState) (StageResul
 	)
 
 	resp, err := s.llm.Complete(ctx, llm.CompletionRequest{
+		// SECURITY: static trusted system prompt — no untrusted data interpolated here.
+		// Untrusted content (issue title, diffs, test output) is passed in the user message only.
 		System: "You are a code reviewer. Start your response with APPROVE or REQUEST_CHANGES.",
 		Messages: []llm.Message{
 			{Role: llm.RoleUser, Content: prompt},

--- a/internal/pipeline/security.go
+++ b/internal/pipeline/security.go
@@ -36,6 +36,8 @@ func (s *SecurityStage) Run(ctx context.Context, state *PipelineState) (StageRes
 	)
 
 	resp, err := s.llm.Complete(ctx, llm.CompletionRequest{
+		// SECURITY: static trusted system prompt — no untrusted data interpolated here.
+		// Untrusted content (plan text, repo name) is passed in the user message only.
 		System: "You are a security reviewer analyzing implementation plans for vulnerabilities.",
 		Messages: []llm.Message{
 			{Role: llm.RoleUser, Content: prompt},


### PR DESCRIPTION
## Implementation for #-991027744

**Issue:** Fix 12 agent_sec_003 security findings

### Approved Plan
### Approach

The 12 security findings reference Python files (`api/llm_sast_scanner.py`, `api/autopilot/workers/issue_agent.py`, etc.) that **do not exist** in this Go repository. This repo (NeuralForge) is a Go codebase with system prompts only in three `internal/pipeline/` files. The SAST scan job `e47b27f` appears to have been attributed to the wrong repository.

That said, the same vulnerability class (`agent_sec_003` — missing SECURITY boundary annotations) does apply to the three Go files where `System:` prompt fields are set. The fix is the same: add an explicit `// SECURITY:` anchor comment above each system prompt assignment to document that no untrusted data is interpolated there.

---

### Files to Modify

| File | Line | Current system prompt |
|---|---|---|
| `internal/pipeline/architect.go` | 32 | `"You are a software architect creating implementation plans."` |
| `internal/pipeline/security.go` | 39 | `"You are a security reviewer analyzing implementation plans for vulnerabilities."` |
| `internal/pipeline/review.go` | 56 | `"You are a code reviewer. Start your response with APPROVE or REQUEST_CHANGES."` |

No other Go files construct `llm.CompletionRequest` with a `System` field.

---

### Implementation Steps

**1. `internal/pipeline/architect.go` (line 31–32)**

Add a `// SECURITY:` anchor comment immediately above the `System:` field:

```go
resp, err := s.llm.Complete(ctx, llm.CompletionRequest{
    // SECURITY: static trusted system prompt — no untrusted data interpolated here.
    // Untrusted content (issue body, codebase context) is passed in the user message only.
    System: "You are a software architect creating implementation plans.",
    Messages: []llm.Message{
        {Role: llm.RoleUser, Content: prompt},
    },
    ...
})
```

**2. `internal/pipeline/security.go` (line 38–39)**

Same pattern:

```go
resp, err := s.llm.Complete(ctx, llm.CompletionRequest{
    // SECURITY: static trusted system prompt — no untrusted data interpolated 

### Files Changed
- `internal/pipeline/architect.go`
- `internal/pipeline/review.go`
- `internal/pipeline/security.go`

---
*Created by NeuralWarden Autopilot (event-driven recovery)*