### PR TITLE
feat: implement #-242920454 — Fix 10 agent_sec_001 security findings

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -24,11 +24,12 @@ import (
 
 // App wires together the store, worker pool, and HTTP server.
 type App struct {
-	cfg    config.Config
-	store  store.Store
-	pool   *worker.Pool
-	server *http.Server
-	ghApp  *ghappauth.App
+	cfg        config.Config
+	store      store.Store
+	pool       *worker.Pool
+	server     *http.Server
+	ghApp      *ghappauth.App
+	llmBackend llm.LLM
 }
 
 // New creates a new App, opens the SQLite store, and runs migrations.
@@ -60,6 +61,24 @@ func New(cfg config.Config) (*App, error) {
 		}
 		a.ghApp = ghApp
 	}
+
+	provider := cfg.LLM.DefaultProvider
+	var apiKey, model string
+	switch provider {
+	case "openai":
+		apiKey = cfg.LLM.OpenAI.APIKey
+		model = cfg.LLM.OpenAI.Model
+	default:
+		provider = "claude"
+		apiKey = cfg.LLM.Claude.APIKey
+		model = cfg.LLM.Claude.Model
+	}
+	backend, err := llm.New(provider, apiKey, model)
+	if err != nil {
+		s.Close()
+		return nil, fmt.Errorf("create llm backend: %w", err)
+	}
+	a.llmBackend = backend
 
 	handler := a.buildJobHandler()
 	a.pool = worker.NewPool(cfg.Workers, s, handler)
@@ -168,17 +187,10 @@ func (a *App) handleEvent(eventType string, payload []byte) {
 	}
 }
 
-// buildJobHandler creates the LLM backend and executor, then returns a handler
-// that clones the repo, builds pipeline state, and runs the pipeline engine.
+// buildJobHandler creates the executor, then returns a handler that clones the
+// repo, builds pipeline state, and runs the pipeline engine.
 func (a *App) buildJobHandler() worker.JobHandler {
-	// Create LLM backend based on config.
-	var backend llm.LLM
-	switch a.cfg.LLM.DefaultProvider {
-	case "openai":
-		backend = llm.NewOpenAI(a.cfg.LLM.OpenAI.APIKey, a.cfg.LLM.OpenAI.Model)
-	default:
-		backend = llm.NewClaude(a.cfg.LLM.Claude.APIKey, a.cfg.LLM.Claude.Model)
-	}
+	backend := a.llmBackend
 
 	// Create executor based on config.
 	var exec executor.Executor

--- a/internal/llm/factory.go
+++ b/internal/llm/factory.go
@@ -10,10 +10,17 @@ import (
 // auditing layer that logs each completion call via slog.
 // provider must be "openai" or "claude" (default).
 //
-// Audit log data-minimization: only request metadata (provider, model,
-// token counts, cost) is logged — prompt content and completions are never
-// written to the audit log, preventing inadvertent capture of PII/PHI that
-// may appear in code diffs, issue bodies, or repository data.
+// Data minimization (GDPR Article 5(1)(c), HIPAA Safe Harbor): only request
+// metadata is logged — provider, model, token counts, and cost. Prompt content,
+// system prompts, and completion text are NEVER written to the audit log,
+// preventing inadvertent capture of PII/PHI that may appear in code diffs,
+// issue bodies, or repository data.
+//
+// Legal basis for logging (GDPR Article 6(1)(f)): audit entries constitute a
+// legitimate interest for security monitoring, abuse prevention, and cost
+// attribution. Logs should be retained according to your organization's data
+// retention policy (recommended: ≤90 days for operational logs) and must not
+// be shared with third parties without a separate legal basis.
 func New(provider, apiKey, model string) (LLM, error) {
 	var backend LLM
 	switch provider {
@@ -39,10 +46,10 @@ func (a *auditedLLM) Name() string { return a.inner.Name() }
 func (a *auditedLLM) Complete(ctx context.Context, req CompletionRequest) (CompletionResponse, error) {
 	resp, err := a.inner.Complete(ctx, req)
 	if err != nil {
-		slog.Warn("llm completion failed", "provider", a.inner.Name(), "model", req.Model, "error", err)
+		slog.WarnContext(ctx, "llm completion failed", "provider", a.inner.Name(), "model", req.Model, "error", err)
 		return resp, err
 	}
-	slog.Info("llm completion",
+	slog.InfoContext(ctx, "llm completion",
 		"provider", a.inner.Name(),
 		"model", resp.Model,
 		"input_tokens", resp.InputTokens,
@@ -55,9 +62,11 @@ func (a *auditedLLM) Complete(ctx context.Context, req CompletionRequest) (Compl
 func (a *auditedLLM) StreamComplete(ctx context.Context, req CompletionRequest) (<-chan StreamChunk, error) {
 	inner, err := a.inner.StreamComplete(ctx, req)
 	if err != nil {
-		slog.Warn("llm stream failed", "provider", a.inner.Name(), "model", req.Model, "error", err)
+		slog.WarnContext(ctx, "llm stream failed", "provider", a.inner.Name(), "model", req.Model, "error", err)
 		return nil, err
 	}
+
+	slog.InfoContext(ctx, "llm stream started", "provider", a.inner.Name(), "model", req.Model)
 
 	out := make(chan StreamChunk)
 	go func() {
@@ -65,9 +74,9 @@ func (a *auditedLLM) StreamComplete(ctx context.Context, req CompletionRequest) 
 		for chunk := range inner {
 			if chunk.Done {
 				if chunk.Error != nil {
-					slog.Warn("llm stream completed with error", "provider", a.inner.Name(), "model", req.Model, "error", chunk.Error)
+					slog.WarnContext(ctx, "llm stream completed with error", "provider", a.inner.Name(), "model", req.Model, "error", chunk.Error)
 				} else {
-					slog.Info("llm stream completed", "provider", a.inner.Name(), "model", req.Model)
+					slog.InfoContext(ctx, "llm stream completed", "provider", a.inner.Name(), "model", req.Model)
 				}
 			}
 			out <- chunk

--- a/internal/llm/factory.go
+++ b/internal/llm/factory.go
@@ -1,0 +1,52 @@
+package llm
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+)
+
+// New creates an LLM backend for the given provider and wraps it in an
+// auditing layer that logs each completion call via slog.
+// provider must be "openai" or "claude" (default).
+func New(provider, apiKey, model string) (LLM, error) {
+	var backend LLM
+	switch provider {
+	case "openai":
+		backend = NewOpenAI(apiKey, model)
+	case "claude", "":
+		backend = NewClaude(apiKey, model)
+	default:
+		return nil, fmt.Errorf("llm.New: unknown provider %q", provider)
+	}
+
+	slog.Info("llm client created", "provider", provider, "model", model)
+	return &auditedLLM{inner: backend}, nil
+}
+
+// auditedLLM wraps any LLM and emits slog audit entries for each call.
+type auditedLLM struct {
+	inner LLM
+}
+
+func (a *auditedLLM) Name() string { return a.inner.Name() }
+
+func (a *auditedLLM) Complete(ctx context.Context, req CompletionRequest) (CompletionResponse, error) {
+	resp, err := a.inner.Complete(ctx, req)
+	if err != nil {
+		slog.Warn("llm completion failed", "provider", a.inner.Name(), "model", req.Model, "error", err)
+		return resp, err
+	}
+	slog.Info("llm completion",
+		"provider", a.inner.Name(),
+		"model", resp.Model,
+		"input_tokens", resp.InputTokens,
+		"output_tokens", resp.OutputTokens,
+		"cost_usd", resp.Cost,
+	)
+	return resp, nil
+}
+
+func (a *auditedLLM) StreamComplete(ctx context.Context, req CompletionRequest) (<-chan StreamChunk, error) {
+	return a.inner.StreamComplete(ctx, req)
+}

--- a/internal/llm/factory.go
+++ b/internal/llm/factory.go
@@ -9,6 +9,11 @@ import (
 // New creates an LLM backend for the given provider and wraps it in an
 // auditing layer that logs each completion call via slog.
 // provider must be "openai" or "claude" (default).
+//
+// Audit log data-minimization: only request metadata (provider, model,
+// token counts, cost) is logged — prompt content and completions are never
+// written to the audit log, preventing inadvertent capture of PII/PHI that
+// may appear in code diffs, issue bodies, or repository data.
 func New(provider, apiKey, model string) (LLM, error) {
 	var backend LLM
 	switch provider {
@@ -48,5 +53,25 @@ func (a *auditedLLM) Complete(ctx context.Context, req CompletionRequest) (Compl
 }
 
 func (a *auditedLLM) StreamComplete(ctx context.Context, req CompletionRequest) (<-chan StreamChunk, error) {
-	return a.inner.StreamComplete(ctx, req)
+	inner, err := a.inner.StreamComplete(ctx, req)
+	if err != nil {
+		slog.Warn("llm stream failed", "provider", a.inner.Name(), "model", req.Model, "error", err)
+		return nil, err
+	}
+
+	out := make(chan StreamChunk)
+	go func() {
+		defer close(out)
+		for chunk := range inner {
+			if chunk.Done {
+				if chunk.Error != nil {
+					slog.Warn("llm stream completed with error", "provider", a.inner.Name(), "model", req.Model, "error", chunk.Error)
+				} else {
+					slog.Info("llm stream completed", "provider", a.inner.Name(), "model", req.Model)
+				}
+			}
+			out <- chunk
+		}
+	}()
+	return out, nil
 }


### PR DESCRIPTION
## Implementation for #-242920454

**Issue:** Fix 10 agent_sec_001 security findings

### Approved Plan
Now I have a full picture of the codebase. Let me note that findings 3–10 reference Python and TypeScript files (`api/`, `frontend/`, `pipeline/`) that **do not exist** in this Go repository — they are false positives from the scan. Only findings 1 and 2 are applicable here.

---

### Approach

Introduce an `llm.New` factory function (in a new `internal/llm/factory.go`) that centralizes LLM client creation and wraps the returned backend in an `auditedLLM` struct that emits `slog` audit log entries for each `Complete` call (provider, model, token counts, cost). Update `internal/app/app.go` to use the factory instead of calling `llm.NewOpenAI`/`llm.NewClaude` directly. Acknowledge findings 3–10 as inapplicable to this repository.

---

### Files to Modify

| File | Action |
|---|---|
| `internal/llm/factory.go` | **Create** — factory function + `auditedLLM` wrapper |
| `internal/app/app.go` | **Modify** — replace direct `llm.NewOpenAI`/`llm.NewClaude` calls with `llm.New` |

---

### Implementation Steps

**1. Create `internal/llm/factory.go`**

```go
package llm

import (
    "context"
    "fmt"
    "log/slog"
)

// New creates an LLM backend for the given provider and wraps it in an
// auditing layer that logs each completion call via slog.
// provider must be "openai" or "claude" (default).
func New(provider, apiKey, model string) (LLM, error) {
    var backend LLM
    switch provider {
    case "openai":
        backend = NewOpenAI(apiKey, model)
    case "claude", "":
        backend = NewClaude(apiKey, model)
    default:
        return nil, fmt.Errorf("llm.New: unknown provider %q", provider)
    }

    slog.Info("llm client created", "provider", provider, "model", model)
    return &auditedLLM{inner: backend}, nil
}

// auditedLLM wraps any LLM and emits slog audit entries for each call.
type auditedLLM struct {
    inner LLM
}

func (a *auditedLLM) Name() string { return a.inner.Name() }

func (a *auditedLLM) Complete(ctx context.Context, req CompletionReques

### Files Changed
- `internal/app/app.go`
- `internal/llm/factory.go`

---
*Created by NeuralWarden Autopilot (event-driven recovery)*