### PR TITLE
feat: implement #-675806268 — Fix 1 osv_ghsa_3ppc_4f35_3m26 security finding

### DIFF
--- a/docs/security-false-positives.md
+++ b/docs/security-false-positives.md
@@ -1,0 +1,19 @@
+# Security False Positives
+
+This file documents security scanner findings that are false positives for this repository.
+
+## GHSA-3ppc-4f35-3m26 — minimatch ReDoS (npm)
+
+- **Scanner finding:** `minimatch@9.0.5` in `frontend/package-lock.json`
+- **CVSS:** 5.0 (Medium)
+- **Status:** False positive — `frontend/package-lock.json` does not exist in this repository.
+
+**Explanation:** NeuralForge is a pure Go project. There is no `frontend/` directory,
+no `package.json`, and no `package-lock.json` on the main branch. The referenced lockfile
+path does not exist, so this finding does not apply to the current codebase.
+
+**Action required:** Dismiss this finding in the security scanner dashboard.
+
+**Future guidance:** If a `frontend/` directory is ever added, pin `minimatch` to `>=9.0.6`
+in `package.json` and run `npm audit --audit-level=moderate` in CI to catch npm
+vulnerabilities proactively.


### PR DESCRIPTION
## Implementation for #-675806268

**Issue:** Fix 1 osv_ghsa_3ppc_4f35_3m26 security finding

### Approved Plan
Now I have enough context to write the plan. The key findings:

1. `frontend/package-lock.json` does **not** exist on `main` — this is a pure Go project
2. GHSA-3ppc-4f35-3m26 is a ReDoS vulnerability in `minimatch`, fixed in `9.0.6`
3. Previous branch `autopilot/issue--4313651` documented this as a false positive via `docs/security-false-positives.md`
4. Another branch `autopilot/issue--576210229` created `frontend/package-lock.json` with `minimatch@9.0.6` (the patched version)
5. The scan job `e47b27f` found the vulnerability, implying a scan was run against some artifact or branch state, not necessarily `main`

---

### Approach

The scanner found `minimatch@9.0.5` in `frontend/package-lock.json`, but this file does not exist on the `main` branch — this is a pure Go project with no npm dependencies. The finding is a **false positive** against the current codebase state. The correct remediation is to document the false positive so it can be dismissed in the scanner, rather than introducing an unneeded `frontend/` directory.

If there is a legitimate use case for a `frontend/` npm project in the future, the fix would be to pin `minimatch` to `>=9.0.6` at that time.

---

### Files to Modify

| File | Action |
|------|--------|
| `docs/security-false-positives.md` | Create — document this finding as a false positive |

---

### Implementation Steps

1. **Create `docs/security-false-positives.md`**

   Create this file with a structured record of the false-positive finding:

   ```markdown
   # Security False Positives

   This file documents security scanner findings that are false positives for this repository.

   ## GHSA-3ppc-4f35-3m26 — minimatch ReDoS (npm)

   - **Scanner finding:** `minimatch@9.0.5` in `frontend/package-lock.json`
   - **CVSS:** 5.0 (Medium)
   - **Status:** False positive — `frontend/package-lock.json` does not exist in this repository.

   **Explanation:** NeuralForge is a pure Go project. There is no `frontend/` directory,
   no `package.j

### Files Changed
- `docs/security-false-positives.md`

---
*Created by NeuralWarden Autopilot (event-driven recovery)*