### PR TITLE
feat: implement #-129755685 — Fix 1 osv_ghsa_2g4f_4pwh_qvx6 security finding

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,0 +1,16 @@
+{
+  "name": "neuralforge-frontend",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "neuralforge-frontend",
+      "version": "0.1.0",
+      "license": "MIT",
+      "overrides": {
+        "ajv": ">=8.0.0"
+      }
+    }
+  }
+}

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "neuralforge-frontend",
+  "version": "0.1.0",
+  "description": "NeuralForge frontend",
+  "license": "MIT",
+  "private": true,
+  "overrides": {
+    "ajv": ">=8.0.0"
+  }
+}


### PR DESCRIPTION
## Implementation for #-129755685

**Issue:** Fix 1 osv_ghsa_2g4f_4pwh_qvx6 security finding

### Approved Plan
### Approach

The security finding GHSA-2g4f-4pwh-qvx6 identifies `ajv` version 6.12.6 in `frontend/package-lock.json` as vulnerable. The `ajv` 6.x branch has an improper input validation vulnerability allowing prototype pollution via specially crafted JSON schemas. The fix is to either remove the vulnerable dependency or use npm's `overrides` field to force resolution of `ajv` to a safe version (>= 8.0.0). The current `main` branch does not have a `frontend/` directory in the working tree — the files must be created (or recreated from their last-known state) with the vulnerability absent.

### Files to Modify

| File | Action |
|---|---|
| `frontend/package.json` | Create — define the frontend package, add `overrides` to force `ajv >= 8.0.0` in case any transitive dependency pulls it in |
| `frontend/package-lock.json` | Create — generated lockfile that does not contain `ajv 6.12.6`; either ajv is absent or resolved to `>= 8.0.0` |

### Implementation Steps

1. **Create `frontend/package.json`**

   Base the file on the most recent version seen in git history (commit `23d7565`) and add an npm `overrides` block to prevent any transitive dependency from resolving `ajv` below `8.0.0`:

   ```json
   {
     "name": "neuralforge-frontend",
     "version": "0.1.0",
     "description": "NeuralForge frontend",
     "license": "MIT",
     "private": true,
     "overrides": {
       "ajv": ">=8.0.0"
     }
   }
   ```

   The `overrides` key is npm v8+ syntax. It forces any transitive resolution of `ajv` to a version satisfying `>=8.0.0`, preventing `6.12.6` from ever appearing in the lock file.

2. **Create `frontend/package-lock.json`**

   Since there are no direct dependencies in `package.json`, the lockfile will be minimal — only the root package entry, with no `ajv` entry at all. If the project later adds a tool that transitively pulls `ajv`, the `overrides` block will ensure it resolves to `>= 8.0.0`. The lockfile should be:

   ```json
   {
     "name": "neuralforge-

### Files Changed
- `frontend/package-lock.json`
- `frontend/package.json`

---
*Created by NeuralWarden Autopilot (event-driven recovery)*