### PR TITLE
feat: implement #-359903745 — Fix 10 agent_sec_001 security findings

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -175,9 +175,9 @@ func (a *App) buildJobHandler() worker.JobHandler {
 	var backend llm.LLM
 	switch a.cfg.LLM.DefaultProvider {
 	case "openai":
-		backend = llm.NewOpenAI(a.cfg.LLM.OpenAI.APIKey, a.cfg.LLM.OpenAI.Model)
+		backend = llm.NewAuditedLLM(llm.NewOpenAI(a.cfg.LLM.OpenAI.APIKey, a.cfg.LLM.OpenAI.Model), slog.Default())
 	default:
-		backend = llm.NewClaude(a.cfg.LLM.Claude.APIKey, a.cfg.LLM.Claude.Model)
+		backend = llm.NewAuditedLLM(llm.NewClaude(a.cfg.LLM.Claude.APIKey, a.cfg.LLM.Claude.Model), slog.Default())
 	}
 
 	// Create executor based on config.

--- a/internal/llm/audit.go
+++ b/internal/llm/audit.go
@@ -5,7 +5,7 @@ package llm
 // Privacy/Legal basis for logging:
 //   - Only metadata is logged (provider, model, token counts, cost, latency, error type).
 //   - Message content is NEVER logged; only the message count is recorded.
-//   - Error messages are truncated to prevent leakage of sensitive API response bodies.
+//   - Error message content is NEVER logged; only the error type name is recorded.
 //   - Callers must ensure that model names and provider names do not themselves
 //     constitute personal data before passing them through.
 //   - This logging constitutes legitimate interest under GDPR Art. 6(1)(f) for
@@ -18,23 +18,15 @@ import (
 	"time"
 )
 
-// maxErrLen is the maximum length of an error message recorded in audit logs.
-// Error strings from upstream APIs may contain sensitive response bodies;
-// truncation limits accidental PII/PHI exposure.
-const maxErrLen = 120
-
-// sanitizeError returns a truncated, safe string representation of err for
-// audit logging. The full error is preserved on the returned Go error value
-// so callers are unaffected.
+// sanitizeError returns only the reflect type name of err for audit logging.
+// Error message content is deliberately excluded to prevent leakage of sensitive
+// API response data (API keys, auth tokens, PII/PHI) into log streams.
+// The full error value is preserved and returned to callers unmodified.
 func sanitizeError(err error) string {
 	if err == nil {
 		return ""
 	}
-	msg := fmt.Sprintf("%T: %s", err, err.Error())
-	if len(msg) > maxErrLen {
-		msg = msg[:maxErrLen] + "…"
-	}
-	return msg
+	return fmt.Sprintf("%T", err)
 }
 
 type AuditedLLM struct {
@@ -57,8 +49,8 @@ func (a *AuditedLLM) Name() string {
 
 func (a *AuditedLLM) Complete(ctx context.Context, req CompletionRequest) (CompletionResponse, error) {
 	start := time.Now()
-	// Log only metadata — message content is not recorded to protect PII/PHI.
-	a.logger.Info("llm.call.start", "provider", a.inner.Name(), "model", req.Model, "messages", len(req.Messages))
+	// Log only the message count — content is never recorded to protect PII/PHI.
+	a.logger.Info("llm.call.start", "provider", a.inner.Name(), "model", req.Model, "message_count", len(req.Messages))
 	resp, err := a.inner.Complete(ctx, req)
 	elapsed := time.Since(start)
 	if err != nil {
@@ -76,8 +68,8 @@ func (a *AuditedLLM) Complete(ctx context.Context, req CompletionRequest) (Compl
 // so output_chars is recorded as a proxy.
 func (a *AuditedLLM) StreamComplete(ctx context.Context, req CompletionRequest) (<-chan StreamChunk, error) {
 	start := time.Now()
-	// Log only metadata — message content is not recorded to protect PII/PHI.
-	a.logger.Info("llm.stream.start", "provider", a.inner.Name(), "model", req.Model, "messages", len(req.Messages))
+	// Log only the message count — content is never recorded to protect PII/PHI.
+	a.logger.Info("llm.stream.start", "provider", a.inner.Name(), "model", req.Model, "message_count", len(req.Messages))
 
 	innerCh, err := a.inner.StreamComplete(ctx, req)
 	if err != nil {
@@ -105,8 +97,12 @@ func (a *AuditedLLM) StreamComplete(ctx context.Context, req CompletionRequest) 
 			}
 		}
 		elapsed := time.Since(start)
+		// Token counts and cost are not available from stream chunks; -1 signals
+		// "not available" for SOX/HIPAA audit consumers. output_chars is a proxy.
 		a.logger.Info("llm.stream.done", "provider", a.inner.Name(), "model", req.Model,
-			"output_chars", outputChars, "duration_ms", elapsed.Milliseconds())
+			"output_chars", outputChars,
+			"input_tokens", -1, "output_tokens", -1, "cost_usd", -1.0,
+			"duration_ms", elapsed.Milliseconds())
 	}()
 	return outCh, nil
 }

--- a/internal/llm/audit.go
+++ b/internal/llm/audit.go
@@ -1,12 +1,42 @@
 package llm
 
+// AuditedLLM wraps an inner LLM and logs audit events for every call.
+//
+// Privacy/Legal basis for logging:
+//   - Only metadata is logged (provider, model, token counts, cost, latency, error type).
+//   - Message content is NEVER logged; only the message count is recorded.
+//   - Error messages are truncated to prevent leakage of sensitive API response bodies.
+//   - Callers must ensure that model names and provider names do not themselves
+//     constitute personal data before passing them through.
+//   - This logging constitutes legitimate interest under GDPR Art. 6(1)(f) for
+//     operational security and financial audit purposes (SOX, HIPAA access logs).
+
 import (
 	"context"
+	"fmt"
 	"log/slog"
 	"time"
 )
 
-// AuditedLLM wraps an inner LLM and logs audit information for every call.
+// maxErrLen is the maximum length of an error message recorded in audit logs.
+// Error strings from upstream APIs may contain sensitive response bodies;
+// truncation limits accidental PII/PHI exposure.
+const maxErrLen = 120
+
+// sanitizeError returns a truncated, safe string representation of err for
+// audit logging. The full error is preserved on the returned Go error value
+// so callers are unaffected.
+func sanitizeError(err error) string {
+	if err == nil {
+		return ""
+	}
+	msg := fmt.Sprintf("%T: %s", err, err.Error())
+	if len(msg) > maxErrLen {
+		msg = msg[:maxErrLen] + "…"
+	}
+	return msg
+}
+
 type AuditedLLM struct {
 	inner  LLM
 	logger *slog.Logger
@@ -27,11 +57,12 @@ func (a *AuditedLLM) Name() string {
 
 func (a *AuditedLLM) Complete(ctx context.Context, req CompletionRequest) (CompletionResponse, error) {
 	start := time.Now()
+	// Log only metadata — message content is not recorded to protect PII/PHI.
 	a.logger.Info("llm.call.start", "provider", a.inner.Name(), "model", req.Model, "messages", len(req.Messages))
 	resp, err := a.inner.Complete(ctx, req)
 	elapsed := time.Since(start)
 	if err != nil {
-		a.logger.Error("llm.call.error", "provider", a.inner.Name(), "model", req.Model, "duration_ms", elapsed.Milliseconds(), "error", err)
+		a.logger.Error("llm.call.error", "provider", a.inner.Name(), "model", req.Model, "duration_ms", elapsed.Milliseconds(), "error", sanitizeError(err))
 		return resp, err
 	}
 	a.logger.Info("llm.call.done", "provider", a.inner.Name(), "model", resp.Model,
@@ -40,7 +71,42 @@ func (a *AuditedLLM) Complete(ctx context.Context, req CompletionRequest) (Compl
 	return resp, nil
 }
 
+// StreamComplete logs start and end audit events (including errors and duration)
+// around the streamed response. Token counts are not available from stream chunks,
+// so output_chars is recorded as a proxy.
 func (a *AuditedLLM) StreamComplete(ctx context.Context, req CompletionRequest) (<-chan StreamChunk, error) {
-	a.logger.Info("llm.stream.start", "provider", a.inner.Name(), "model", req.Model)
-	return a.inner.StreamComplete(ctx, req)
+	start := time.Now()
+	// Log only metadata — message content is not recorded to protect PII/PHI.
+	a.logger.Info("llm.stream.start", "provider", a.inner.Name(), "model", req.Model, "messages", len(req.Messages))
+
+	innerCh, err := a.inner.StreamComplete(ctx, req)
+	if err != nil {
+		elapsed := time.Since(start)
+		a.logger.Error("llm.stream.error", "provider", a.inner.Name(), "model", req.Model,
+			"duration_ms", elapsed.Milliseconds(), "error", sanitizeError(err))
+		return nil, err
+	}
+
+	outCh := make(chan StreamChunk)
+	go func() {
+		defer close(outCh)
+		var outputChars int
+		for chunk := range innerCh {
+			outputChars += len(chunk.Content)
+			outCh <- chunk
+			if chunk.Error != nil {
+				elapsed := time.Since(start)
+				a.logger.Error("llm.stream.error", "provider", a.inner.Name(), "model", req.Model,
+					"duration_ms", elapsed.Milliseconds(), "error", sanitizeError(chunk.Error))
+				return
+			}
+			if chunk.Done {
+				break
+			}
+		}
+		elapsed := time.Since(start)
+		a.logger.Info("llm.stream.done", "provider", a.inner.Name(), "model", req.Model,
+			"output_chars", outputChars, "duration_ms", elapsed.Milliseconds())
+	}()
+	return outCh, nil
 }

--- a/internal/llm/audit.go
+++ b/internal/llm/audit.go
@@ -1,0 +1,46 @@
+package llm
+
+import (
+	"context"
+	"log/slog"
+	"time"
+)
+
+// AuditedLLM wraps an inner LLM and logs audit information for every call.
+type AuditedLLM struct {
+	inner  LLM
+	logger *slog.Logger
+}
+
+// NewAuditedLLM returns an LLM that delegates to inner and logs audit events.
+// If logger is nil, slog.Default() is used.
+func NewAuditedLLM(inner LLM, logger *slog.Logger) LLM {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &AuditedLLM{inner: inner, logger: logger}
+}
+
+func (a *AuditedLLM) Name() string {
+	return "audited/" + a.inner.Name()
+}
+
+func (a *AuditedLLM) Complete(ctx context.Context, req CompletionRequest) (CompletionResponse, error) {
+	start := time.Now()
+	a.logger.Info("llm.call.start", "provider", a.inner.Name(), "model", req.Model, "messages", len(req.Messages))
+	resp, err := a.inner.Complete(ctx, req)
+	elapsed := time.Since(start)
+	if err != nil {
+		a.logger.Error("llm.call.error", "provider", a.inner.Name(), "model", req.Model, "duration_ms", elapsed.Milliseconds(), "error", err)
+		return resp, err
+	}
+	a.logger.Info("llm.call.done", "provider", a.inner.Name(), "model", resp.Model,
+		"input_tokens", resp.InputTokens, "output_tokens", resp.OutputTokens,
+		"cost_usd", resp.Cost, "duration_ms", elapsed.Milliseconds())
+	return resp, nil
+}
+
+func (a *AuditedLLM) StreamComplete(ctx context.Context, req CompletionRequest) (<-chan StreamChunk, error) {
+	a.logger.Info("llm.stream.start", "provider", a.inner.Name(), "model", req.Model)
+	return a.inner.StreamComplete(ctx, req)
+}

--- a/internal/llm/audit_test.go
+++ b/internal/llm/audit_test.go
@@ -1,0 +1,104 @@
+package llm
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"log/slog"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type mockLLM struct {
+	name     string
+	resp     CompletionResponse
+	err      error
+	calls    int
+}
+
+func (m *mockLLM) Name() string { return m.name }
+
+func (m *mockLLM) Complete(_ context.Context, _ CompletionRequest) (CompletionResponse, error) {
+	m.calls++
+	return m.resp, m.err
+}
+
+func (m *mockLLM) StreamComplete(_ context.Context, _ CompletionRequest) (<-chan StreamChunk, error) {
+	ch := make(chan StreamChunk)
+	close(ch)
+	return ch, m.err
+}
+
+func newTestLogger(buf *bytes.Buffer) *slog.Logger {
+	return slog.New(slog.NewTextHandler(buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+}
+
+func TestAuditedLLM_Name(t *testing.T) {
+	mock := &mockLLM{name: "mock"}
+	audited := NewAuditedLLM(mock, nil)
+	assert.Equal(t, "audited/mock", audited.Name())
+}
+
+func TestAuditedLLM_Complete(t *testing.T) {
+	tests := []struct {
+		name        string
+		resp        CompletionResponse
+		err         error
+		wantLogKeys []string
+		wantErr     bool
+	}{
+		{
+			name: "success",
+			resp: CompletionResponse{
+				Content:      "hello",
+				Model:        "gpt-4",
+				InputTokens:  10,
+				OutputTokens: 5,
+				Cost:         0.001,
+			},
+			wantLogKeys: []string{"llm.call.start", "llm.call.done", "provider", "model", "cost_usd", "duration_ms"},
+		},
+		{
+			name:        "error",
+			err:         errors.New("api failure"),
+			wantLogKeys: []string{"llm.call.start", "llm.call.error", "provider", "model", "duration_ms", "error"},
+			wantErr:     true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			logger := newTestLogger(&buf)
+			mock := &mockLLM{name: "testprovider", resp: tc.resp, err: tc.err}
+			audited := NewAuditedLLM(mock, logger)
+
+			req := CompletionRequest{Model: "gpt-4", Messages: []Message{{Role: RoleUser, Content: "hi"}}}
+			resp, err := audited.Complete(context.Background(), req)
+
+			if tc.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tc.resp, resp)
+			}
+			assert.Equal(t, 1, mock.calls)
+
+			logOutput := buf.String()
+			for _, key := range tc.wantLogKeys {
+				assert.True(t, strings.Contains(logOutput, key), "expected log key %q in output: %s", key, logOutput)
+			}
+		})
+	}
+}
+
+func TestAuditedLLM_NilLogger(t *testing.T) {
+	mock := &mockLLM{name: "mock", resp: CompletionResponse{Content: "ok"}}
+	audited := NewAuditedLLM(mock, nil)
+	// Should not panic with nil logger.
+	_, err := audited.Complete(context.Background(), CompletionRequest{})
+	assert.NoError(t, err)
+}

--- a/internal/llm/audit_test.go
+++ b/internal/llm/audit_test.go
@@ -102,3 +102,72 @@ func TestAuditedLLM_NilLogger(t *testing.T) {
 	_, err := audited.Complete(context.Background(), CompletionRequest{})
 	assert.NoError(t, err)
 }
+
+func TestAuditedLLM_StreamComplete(t *testing.T) {
+	t.Run("success logs start and done", func(t *testing.T) {
+		var buf bytes.Buffer
+		logger := newTestLogger(&buf)
+		mock := &mockLLM{name: "streamprovider"}
+		audited := NewAuditedLLM(mock, logger)
+
+		ch, err := audited.StreamComplete(context.Background(), CompletionRequest{Model: "gpt-4"})
+		require.NoError(t, err)
+		// Drain the channel (mock closes it immediately with Done chunk).
+		for range ch {
+		}
+
+		logOutput := buf.String()
+		for _, key := range []string{"llm.stream.start", "llm.stream.done", "provider", "model", "duration_ms"} {
+			assert.True(t, strings.Contains(logOutput, key), "expected log key %q in output: %s", key, logOutput)
+		}
+	})
+
+	t.Run("init error logs stream.error", func(t *testing.T) {
+		var buf bytes.Buffer
+		logger := newTestLogger(&buf)
+		mock := &mockLLM{name: "streamprovider", err: errors.New("dial tcp: connection refused")}
+		audited := NewAuditedLLM(mock, logger)
+
+		_, err := audited.StreamComplete(context.Background(), CompletionRequest{Model: "gpt-4"})
+		require.Error(t, err)
+
+		logOutput := buf.String()
+		for _, key := range []string{"llm.stream.start", "llm.stream.error", "duration_ms"} {
+			assert.True(t, strings.Contains(logOutput, key), "expected log key %q in output: %s", key, logOutput)
+		}
+		// Full error message should be truncated / sanitized, not absent entirely.
+		assert.True(t, strings.Contains(logOutput, "error"), "expected error key in output")
+	})
+}
+
+func TestSanitizeError(t *testing.T) {
+	assert.Equal(t, "", sanitizeError(nil))
+
+	short := errors.New("short error")
+	out := sanitizeError(short)
+	assert.True(t, strings.Contains(out, "short error"))
+
+	// Build an error whose message exceeds maxErrLen.
+	longMsg := strings.Repeat("x", maxErrLen+50)
+	long := errors.New(longMsg)
+	out = sanitizeError(long)
+	assert.LessOrEqual(t, len(out), maxErrLen+10, "sanitized error should be truncated")
+	assert.True(t, strings.HasSuffix(out, "…"), "truncated error should end with ellipsis")
+}
+
+func TestAuditedLLM_ErrorSanitized(t *testing.T) {
+	// Verify that sensitive data in an error is truncated in logs but full error
+	// is returned to the caller.
+	var buf bytes.Buffer
+	logger := newTestLogger(&buf)
+	sensitiveErr := errors.New("api_key=sk-secret123 token=eyJhb user_id=42 " + strings.Repeat("sensitive", 20))
+	mock := &mockLLM{name: "prov", err: sensitiveErr}
+	audited := NewAuditedLLM(mock, logger)
+
+	_, err := audited.Complete(context.Background(), CompletionRequest{})
+	require.ErrorIs(t, err, sensitiveErr) // full error returned to caller
+
+	logOutput := buf.String()
+	// Log line should not contain the full repeated "sensitive" blob.
+	assert.False(t, strings.Contains(logOutput, strings.Repeat("sensitive", 20)), "full sensitive error must not appear in logs")
+}

--- a/internal/llm/audit_test.go
+++ b/internal/llm/audit_test.go
@@ -117,7 +117,7 @@ func TestAuditedLLM_StreamComplete(t *testing.T) {
 		}
 
 		logOutput := buf.String()
-		for _, key := range []string{"llm.stream.start", "llm.stream.done", "provider", "model", "duration_ms"} {
+		for _, key := range []string{"llm.stream.start", "llm.stream.done", "provider", "model", "duration_ms", "input_tokens", "output_tokens", "cost_usd"} {
 			assert.True(t, strings.Contains(logOutput, key), "expected log key %q in output: %s", key, logOutput)
 		}
 	})
@@ -145,14 +145,16 @@ func TestSanitizeError(t *testing.T) {
 
 	short := errors.New("short error")
 	out := sanitizeError(short)
-	assert.True(t, strings.Contains(out, "short error"))
+	// Only the type should be logged — message content must not appear in audit logs.
+	assert.NotContains(t, out, "short error", "error message content must not appear in sanitized output")
+	assert.NotEmpty(t, out, "sanitized output must not be empty for non-nil error")
 
-	// Build an error whose message exceeds maxErrLen.
-	longMsg := strings.Repeat("x", maxErrLen+50)
+	// Long errors should also only log the type, never the full message.
+	longMsg := strings.Repeat("x", 200)
 	long := errors.New(longMsg)
 	out = sanitizeError(long)
-	assert.LessOrEqual(t, len(out), maxErrLen+10, "sanitized error should be truncated")
-	assert.True(t, strings.HasSuffix(out, "…"), "truncated error should end with ellipsis")
+	assert.NotContains(t, out, longMsg, "error message must not appear in sanitized output")
+	assert.NotEmpty(t, out)
 }
 
 func TestAuditedLLM_ErrorSanitized(t *testing.T) {


### PR DESCRIPTION
## Implementation for #-359903745

**Issue:** Fix 10 agent_sec_001 security findings

### Approved Plan
---

### Approach

Create an auditing wrapper (`AuditedLLM`) in the `internal/llm` package that implements the `LLM` interface and logs audit information (provider, model, token counts, cost, latency, errors) for every call. Update `internal/app/app.go` to route both OpenAI and Claude backends through this wrapper instead of using them directly.

The 8 findings in `api/`, `frontend/`, and `pipeline/` paths do **not exist** in this repository — this is a Go-only codebase. Those findings were likely generated by a scanner run against a different (larger) monorepo. This PR can only address the 2 findings within scope here:
- `internal/app/app.go:178`
- `internal/llm/openai.go:17`

---

### Files to Modify

| File | Action |
|---|---|
| `internal/llm/audit.go` | **Create** — auditing wrapper implementing `LLM` interface |
| `internal/app/app.go` | **Modify** — wrap backends with `llm.NewAuditedLLM(backend)` |

---

### Implementation Steps

**1. Create `internal/llm/audit.go`**

Define a struct `AuditedLLM` that holds an inner `LLM` and a `*slog.Logger`. Provide a constructor `NewAuditedLLM(inner LLM, logger *slog.Logger) LLM`.

Implement the `LLM` interface methods:

- `Name()` — delegate to inner: `return "audited/" + a.inner.Name()`
- `Complete()` — log before and after:
  ```go
  func (a *AuditedLLM) Complete(ctx context.Context, req CompletionRequest) (CompletionResponse, error) {
      start := time.Now()
      a.logger.Info("llm.call.start", "provider", a.inner.Name(), "model", req.Model, "messages", len(req.Messages))
      resp, err := a.inner.Complete(ctx, req)
      elapsed := time.Since(start)
      if err != nil {
          a.logger.Error("llm.call.error", "provider", a.inner.Name(), "model", req.Model, "duration_ms", elapsed.Milliseconds(), "error", err)
          return resp, err
      }
      a.logger.Info("llm.call.done", "provider", a.inner.Name(), "model", resp.Model,
          "input_tokens", resp.InputTokens, "output_tokens", resp.OutputTokens,
    

### Files Changed
- `internal/app/app.go`
- `internal/llm/audit.go`
- `internal/llm/audit_test.go`

---
*Created by NeuralWarden Autopilot (event-driven recovery)*