### PR TITLE
feat: implement #-276150058 — Fix 1 osv_ghsa_hp87_p4gw_j4gq security finding

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/openai/openai-go v1.12.0
 	github.com/spf13/cobra v1.10.2
 	github.com/stretchr/testify v1.11.1
-	gopkg.in/yaml.v3 v3.0.1
+	gopkg.in/yaml.v3 v3.0.1 // min v3.0.1: GHSA-HP87-P4GW-J4GQ (DoS fixed in v3.0.1)
 	k8s.io/api v0.35.2
 	k8s.io/apimachinery v0.35.2
 	k8s.io/client-go v0.35.2

--- a/go.sum
+++ b/go.sum
@@ -149,7 +149,6 @@ gopkg.in/inf.v0 v0.9.1 h1:73M5CoZyi3ZLMOyDlQh031Cx6N9NDJ2Vvfl76EDAgDc=
 gopkg.in/inf.v0 v0.9.1/go.mod h1:cWUDdTG/fYaXco+Dcufb5Vnc6Gp2YChqWtbxRZE0mXw=
 gopkg.in/yaml.v2 v2.2.8 h1:obN1ZagJSUGI0Ek/LBmuj4SNLPfIny3KsKFopxRdj10=
 gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
-gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 k8s.io/api v0.35.2 h1:tW7mWc2RpxW7HS4CoRXhtYHSzme1PN1UjGHJ1bdrtdw=


### PR DESCRIPTION
## Implementation for #-276150058

**Issue:** Fix 1 osv_ghsa_hp87_p4gw_j4gq security finding

### Approved Plan
### Approach

The security scanner flags `gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c` in `go.sum` as vulnerable (GHSA-HP87-P4GW-J4GQ — a DoS via stack overflow on crafted YAML). 

`go.mod` already pins `gopkg.in/yaml.v3 v3.0.1` (the patched release), so the compiled binary is safe. However, `go.sum` retains a `/go.mod`-only hash entry for the old vulnerable version (`v3.0.0-20200313102051-9f266ea9e77c/go.mod`) because some transitive dependency's own `go.mod` still references that older version, causing the scanner to flag it.

The fix is to run `go mod tidy` to prune stale go.sum entries. If the entry persists (meaning it's still needed for module graph resolution), the offending indirect dependency must be identified and upgraded.

---

### Files to Modify

| File | Change |
|------|--------|
| `go.sum` | Remove the stale `gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod` entry via `go mod tidy` |
| `go.mod` | Possibly add an explicit `require` bump for the indirect dependency that transitively references the old version (only if `go mod tidy` alone doesn't resolve it) |

---

### Implementation Steps

1. **Run `go mod tidy`** from the repo root:
   ```
   go mod tidy
   ```
   This removes go.sum entries that are no longer needed for the current dependency graph.

2. **Verify the stale entry is gone** — confirm `go.sum` no longer contains:
   ```
   gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod
   ```

3. **If the entry persists**, identify the culprit transitive dependency:
   ```
   go mod graph | grep "gopkg.in/yaml.v3@v3.0.0"
   ```
   This prints which module still declares a requirement on the old version. Then upgrade that module:
   ```
   go get <culprit-module>@latest
   go mod tidy
   ```
   Typical suspects given this dependency tree: `github.com/stretchr/testify`, `github.com/go-openapi/swag`, or `sigs.k8s.io/yaml`.

4. **Verify build and tests still pass**:
   ```
   make build
   make test
   ```

---

### Testing

-

### Files Changed
- `go.sum`

---
*Created by NeuralWarden Autopilot (event-driven recovery)*