### PR TITLE
feat: implement #-968973225 — Fix 1 osv_go_2022_0603 security finding

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -149,7 +149,6 @@ gopkg.in/inf.v0 v0.9.1 h1:73M5CoZyi3ZLMOyDlQh031Cx6N9NDJ2Vvfl76EDAgDc=
 gopkg.in/inf.v0 v0.9.1/go.mod h1:cWUDdTG/fYaXco+Dcufb5Vnc6Gp2YChqWtbxRZE0mXw=
 gopkg.in/yaml.v2 v2.2.8 h1:obN1ZagJSUGI0Ek/LBmuj4SNLPfIny3KsKFopxRdj10=
 gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
-gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 k8s.io/api v0.35.2 h1:tW7mWc2RpxW7HS4CoRXhtYHSzme1PN1UjGHJ1bdrtdw=


### PR DESCRIPTION
## Implementation for #-968973225

**Issue:** Fix 1 osv_go_2022_0603 security finding

### Approved Plan
The analysis is complete. Here is the implementation plan:

---

### Approach

The security scanner flagged `gopkg.in/yaml.v3 3.0.0-20200313102051-9f266ea9e77c` in `go.sum`. However, `go.mod` already declares `gopkg.in/yaml.v3 v3.0.1` (the patched version). The vulnerable pre-release version appears **only** as a `/go.mod` hash entry in `go.sum` (line 152) — a stale artifact used by Go's module graph resolution — with no corresponding `h1:` (source download) entry. The actual code compiled is `v3.0.1`.

The fix is to run `go mod tidy` to remove the stale `go.sum` entry for the vulnerable pre-release version. No source code changes are needed.

---

### Files to Modify

| File | Change |
|------|--------|
| `go.sum` | Remove stale `gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod` entry via `go mod tidy` |

`go.mod` does **not** need to change — it already pins `v3.0.1`.

---

### Implementation Steps

1. **Run `go mod tidy`** from the repo root:
   ```
   go mod tidy
   ```
   This removes the stale `go.sum` entry:
   ```
   gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
   ```
   The retained entries for `v3.0.1` remain untouched.

2. **Verify** the resulting `go.sum` no longer contains `3.0.0-20200313102051-9f266ea9e77c`.

---

### Testing

- After `go mod tidy`, confirm `go.sum` no longer has any line mentioning `v3.0.0-20200313102051-9f266ea9e77c`.
- Run `make build` — must compile cleanly.
- Run `make test` — all tests must pass.
- Re-run the OSV scanner (`govulncheck ./...` or equivalent) and confirm zero findings for `GO-2022-0603`.

---

### Risks

- **Low risk**: `go mod tidy` is non-destructive for compile-time code; it only removes unnecessary `go.sum` hashes. The direct dependency on `v3.0.1` (fixed version) in `go.mod` is unchanged.
- No other transitive dependencies should require the pre-release version, given `v3.0.1` is already resolved.
- The stale entry exists purely because a t

### Files Changed
- `go.sum`

---
*Created by NeuralWarden Autopilot (event-driven recovery)*