### PR TITLE
feat: implement #-899302348 — Fix 9 agent_sec_002 security findings

### DIFF
--- a/internal/llm/claude.go
+++ b/internal/llm/claude.go
@@ -29,7 +29,8 @@ func (c *ClaudeBackend) Name() string {
 
 func (c *ClaudeBackend) Complete(ctx context.Context, req CompletionRequest) (CompletionResponse, error) {
 	if req.AgentName != "" {
-		slog.InfoContext(ctx, "llm_call", "backend", "claude", "agent", req.AgentName, "model", req.Model)
+		// sanitizeAgentName enforces an allowlist, preventing PII/PHI from appearing in logs.
+		slog.InfoContext(ctx, "llm_call", "backend", "claude", "agent", sanitizeAgentName(req.AgentName), "model", req.Model)
 	}
 
 	model := req.Model

--- a/internal/llm/claude.go
+++ b/internal/llm/claude.go
@@ -3,6 +3,7 @@ package llm
 import (
 	"context"
 	"fmt"
+	"log/slog"
 
 	anthropic "github.com/anthropics/anthropic-sdk-go"
 	"github.com/anthropics/anthropic-sdk-go/option"
@@ -27,6 +28,10 @@ func (c *ClaudeBackend) Name() string {
 }
 
 func (c *ClaudeBackend) Complete(ctx context.Context, req CompletionRequest) (CompletionResponse, error) {
+	if req.AgentName != "" {
+		slog.InfoContext(ctx, "llm_call", "backend", "claude", "agent", req.AgentName, "model", req.Model)
+	}
+
 	model := req.Model
 	if model == "" {
 		model = c.model

--- a/internal/llm/llm.go
+++ b/internal/llm/llm.go
@@ -17,7 +17,10 @@ type Message struct {
 
 type CompletionRequest struct {
 	// AgentName identifies the pipeline stage for local audit logging only.
-	// json:"-" ensures it is never serialized and cannot be transmitted to external LLM providers.
+	// json:"-" ensures this field is NEVER serialized or transmitted to any external LLM provider
+	// (Anthropic, OpenAI, etc.). It is consumed solely by local slog instrumentation.
+	// Values must be static pipeline-stage identifiers (e.g. "architect", "review", "security").
+	// Do NOT populate this field with user-supplied input, PII, PHI, or financial data.
 	AgentName string `json:"-"`
 	System      string    `json:"system"`
 	Messages    []Message `json:"messages"`
@@ -44,4 +47,22 @@ type LLM interface {
 	Complete(ctx context.Context, req CompletionRequest) (CompletionResponse, error)
 	StreamComplete(ctx context.Context, req CompletionRequest) (<-chan StreamChunk, error)
 	Name() string
+}
+
+// knownAgents is the allowlist of pipeline-stage identifiers permitted in audit logs.
+// Only static, code-defined values appear here — never user-supplied input.
+var knownAgents = map[string]struct{}{
+	"architect": {},
+	"review":    {},
+	"security":  {},
+}
+
+// sanitizeAgentName returns the agent name if it is a known pipeline stage, or "[unknown]"
+// otherwise. This prevents accidental logging of PII/PHI if a caller incorrectly populates
+// AgentName with dynamic or user-supplied data.
+func sanitizeAgentName(name string) string {
+	if _, ok := knownAgents[name]; ok {
+		return name
+	}
+	return "[unknown]"
 }

--- a/internal/llm/llm.go
+++ b/internal/llm/llm.go
@@ -17,8 +17,8 @@ type Message struct {
 
 type CompletionRequest struct {
 	// AgentName identifies the pipeline stage for local audit logging only.
-	// It is NOT transmitted to external LLM providers (Anthropic, OpenAI).
-	AgentName   string
+	// json:"-" ensures it is never serialized and cannot be transmitted to external LLM providers.
+	AgentName string `json:"-"`
 	System      string    `json:"system"`
 	Messages    []Message `json:"messages"`
 	Model       string    `json:"model"`

--- a/internal/llm/llm.go
+++ b/internal/llm/llm.go
@@ -16,7 +16,9 @@ type Message struct {
 }
 
 type CompletionRequest struct {
-	AgentName   string    `json:"agent_name,omitempty"` // for audit attribution
+	// AgentName identifies the pipeline stage for local audit logging only.
+	// It is NOT transmitted to external LLM providers (Anthropic, OpenAI).
+	AgentName   string
 	System      string    `json:"system"`
 	Messages    []Message `json:"messages"`
 	Model       string    `json:"model"`

--- a/internal/llm/llm.go
+++ b/internal/llm/llm.go
@@ -16,6 +16,7 @@ type Message struct {
 }
 
 type CompletionRequest struct {
+	AgentName   string    `json:"agent_name,omitempty"` // for audit attribution
 	System      string    `json:"system"`
 	Messages    []Message `json:"messages"`
 	Model       string    `json:"model"`

--- a/internal/llm/openai.go
+++ b/internal/llm/openai.go
@@ -29,7 +29,8 @@ func (o *OpenAIBackend) Name() string {
 
 func (o *OpenAIBackend) Complete(ctx context.Context, req CompletionRequest) (CompletionResponse, error) {
 	if req.AgentName != "" {
-		slog.InfoContext(ctx, "llm_call", "backend", "openai", "agent", req.AgentName, "model", req.Model)
+		// sanitizeAgentName enforces an allowlist, preventing PII/PHI from appearing in logs.
+		slog.InfoContext(ctx, "llm_call", "backend", "openai", "agent", sanitizeAgentName(req.AgentName), "model", req.Model)
 	}
 
 	model := req.Model

--- a/internal/llm/openai.go
+++ b/internal/llm/openai.go
@@ -3,6 +3,7 @@ package llm
 import (
 	"context"
 	"fmt"
+	"log/slog"
 
 	openai "github.com/openai/openai-go"
 	"github.com/openai/openai-go/option"
@@ -27,6 +28,10 @@ func (o *OpenAIBackend) Name() string {
 }
 
 func (o *OpenAIBackend) Complete(ctx context.Context, req CompletionRequest) (CompletionResponse, error) {
+	if req.AgentName != "" {
+		slog.InfoContext(ctx, "llm_call", "backend", "openai", "agent", req.AgentName, "model", req.Model)
+	}
+
 	model := req.Model
 	if model == "" {
 		model = o.model

--- a/internal/pipeline/architect.go
+++ b/internal/pipeline/architect.go
@@ -29,7 +29,8 @@ func (s *ArchitectStage) Run(ctx context.Context, state *PipelineState) (StageRe
 	)
 
 	resp, err := s.llm.Complete(ctx, llm.CompletionRequest{
-		System: "You are a software architect creating implementation plans.",
+		AgentName: s.Name(),
+		System:    "You are a software architect creating implementation plans.",
 		Messages: []llm.Message{
 			{Role: llm.RoleUser, Content: prompt},
 		},

--- a/internal/pipeline/review.go
+++ b/internal/pipeline/review.go
@@ -53,7 +53,8 @@ func (s *ReviewStage) Run(ctx context.Context, state *PipelineState) (StageResul
 	)
 
 	resp, err := s.llm.Complete(ctx, llm.CompletionRequest{
-		System: "You are a code reviewer. Start your response with APPROVE or REQUEST_CHANGES.",
+		AgentName: s.Name(),
+		System:    "You are a code reviewer. Start your response with APPROVE or REQUEST_CHANGES.",
 		Messages: []llm.Message{
 			{Role: llm.RoleUser, Content: prompt},
 		},

--- a/internal/pipeline/security.go
+++ b/internal/pipeline/security.go
@@ -36,7 +36,8 @@ func (s *SecurityStage) Run(ctx context.Context, state *PipelineState) (StageRes
 	)
 
 	resp, err := s.llm.Complete(ctx, llm.CompletionRequest{
-		System: "You are a security reviewer analyzing implementation plans for vulnerabilities.",
+		AgentName: s.Name(),
+		System:    "You are a security reviewer analyzing implementation plans for vulnerabilities.",
 		Messages: []llm.Message{
 			{Role: llm.RoleUser, Content: prompt},
 		},


### PR DESCRIPTION
## Implementation for #-899302348

**Issue:** Fix 9 agent_sec_002 security findings

### Approved Plan
### Approach

**Note:** The issue references Python files (`api/llm_sast_scanner.py`, `api/autopilot/review_rules.py`, `pipeline/config.py`, `pipeline/llm_factory.py`) that **do not exist** in this repository. This is a Go codebase. The SAST scanner appears to have scanned a different service's Python code and filed the issue against this repo in error.

However, the **underlying security concern applies here** in the Go equivalent: the `llm.CompletionRequest` struct has no `AgentName` field, so LLM calls made by pipeline stages (`architect`, `review`, `security`) cannot be attributed to their caller in audit logs. This plan addresses that equivalent gap.

---

### Files to Modify

| File | Change |
|------|--------|
| `internal/llm/llm.go` | Add `AgentName string` field to `CompletionRequest` |
| `internal/llm/claude.go` | Log `AgentName` from request in the `Complete()` method |
| `internal/llm/openai.go` | Log `AgentName` from request in the `Complete()` method |
| `internal/pipeline/architect.go` | Populate `AgentName: s.Name()` in `CompletionRequest` |
| `internal/pipeline/review.go` | Populate `AgentName: s.Name()` in `CompletionRequest` |
| `internal/pipeline/security.go` | Populate `AgentName: s.Name()` in `CompletionRequest` |

---

### Implementation Steps

**Step 1 — `internal/llm/llm.go`**

Add `AgentName` to `CompletionRequest`:
```go
type CompletionRequest struct {
    AgentName   string    `json:"agent_name,omitempty"` // for audit attribution
    System      string    `json:"system"`
    Messages    []Message `json:"messages"`
    Model       string    `json:"model"`
    MaxTokens   int       `json:"max_tokens"`
    Temperature float64   `json:"temperature"`
}
```

**Step 2 — `internal/llm/claude.go`**

At the top of `Complete()`, add attribution logging before sending the request:
```go
func (c *ClaudeBackend) Complete(ctx context.Context, req CompletionRequest) (CompletionResponse, error) {
    if req.AgentName != "" {
        // structured log for

### Files Changed
- `internal/llm/claude.go`
- `internal/llm/llm.go`
- `internal/llm/openai.go`
- `internal/pipeline/architect.go`
- `internal/pipeline/review.go`
- `internal/pipeline/security.go`

---
*Created by NeuralWarden Autopilot (event-driven recovery)*