### PR TITLE
feat: implement #-520031844 — Fix 1 llm_010 security finding

### DIFF
--- a/docs/security-findings.md
+++ b/docs/security-findings.md
@@ -1,0 +1,28 @@
+# Security Findings Log
+
+## llm_010 — False Positive (job repo:e47b27f)
+
+**Finding:** Restrict model access with authentication. Do not serve raw model files publicly.
+**Reported file:** `api/schemas.py:562`
+**Severity:** HIGH
+
+**Status: FALSE POSITIVE — file does not exist in this repository.**
+
+### Analysis
+
+This repository is a pure Go project. There are no Python source files and no `api/` directory. The scanner job `repo:e47b27f` appears to have been run against a different codebase (likely a Python/Django service) and the finding was incorrectly attributed to this repository.
+
+### HTTP Surface Review
+
+The only externally reachable endpoints in this application are:
+
+| Endpoint | Auth | Data exposed |
+|---|---|---|
+| `POST /webhooks/github` | HMAC signature verification | None — processes webhook events only |
+| `GET /health` | None | `{"status":"ok"}` (static string) |
+
+LLM provider API keys and model names are loaded from environment variables, kept only in memory, and are never written to any HTTP response. No endpoint proxies or exposes raw model calls externally.
+
+### Conclusion
+
+No code changes are required. The finding should be closed as a false positive. The autopilot scan job configuration should be audited to ensure scans are mapped to the correct repository.


### PR DESCRIPTION
## Implementation for #-520031844

**Issue:** Fix 1 llm_010 security finding

### Approved Plan
### Approach

The security finding `llm_010` references `api/schemas.py:562` with the message "Restrict model access with authentication. Do not serve raw model files publicly." However, after a thorough inspection of the repository, **this file does not exist** — this is a pure Go project with no Python source files and no `api/` directory. The scan appears to have been run against a different codebase and the finding was incorrectly associated with this repository.

To be thorough, I also reviewed the actual HTTP surface of this application to assess whether any analogous concern applies:

- **`/webhooks/github`** — protected by HMAC signature verification (`ghApp.WebhookMiddleware` or `NewWebhookHandler`). Not publicly exploitable.
- **`/health`** — public, returns only `{"status":"ok"}`. No sensitive model data is exposed.
- **LLM backends** (`internal/llm/claude.go`, `internal/llm/openai.go`) — API keys come from environment variables, are kept only in memory, and are never written to any HTTP response. No endpoint proxies or exposes raw model calls externally.

There is no equivalent of "serving raw model files publicly" in this codebase. LLM provider API keys and model names are strictly internal.

---

### Files to Modify

None. The referenced file (`api/schemas.py`) does not exist in this repository, and no analogous vulnerability was found in the actual Go source.

---

### Implementation Steps

1. **Verify the scan provenance.** Confirm that job `repo:e47b27f` was actually run against this repository (`mandadapu/neuralforge`). If the job targeted a different repo (e.g., a Python/Django service), the finding should be closed as a false positive here.

2. **No code changes required.** The application does not serve LLM model files, does not expose API keys via HTTP, and all externally reachable endpoints are either HMAC-authenticated or return only a static health string.

3. *(Optional hardening, if ever a model-info endpoint is added in the future)* Any f

### Files Changed
- `docs/security-findings.md`

---
*Created by NeuralWarden Autopilot (event-driven recovery)*