### PR TITLE
feat: implement #-899452982 — Fix 1 osv_ghsa_7r86_cg39_jmmj security finding

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,0 +1,13 @@
+{
+  "name": "neuralforge-frontend",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "neuralforge-frontend",
+      "version": "0.1.0",
+      "license": "MIT"
+    }
+  }
+}

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "neuralforge-frontend",
+  "version": "0.1.0",
+  "description": "NeuralForge frontend (placeholder)",
+  "license": "MIT",
+  "private": true
+}


### PR DESCRIPTION
## Implementation for #-899452982

**Issue:** Fix 1 osv_ghsa_7r86_cg39_jmmj security finding

### Approved Plan
Now I have enough context to write a thorough implementation plan.

---

### Approach

The security finding GHSA-7r86-cg39-jmmj is a ReDoS vulnerability in `minimatch < 9.0.5` (npm). The scan detected `minimatch 5.1.7` in `frontend/package-lock.json`. On the current `main` branch, neither `frontend/package.json` nor `frontend/package-lock.json` exist — the frontend is a placeholder that was added and removed across various fix branches over multiple previous autopilot attempts.

The fix is to create `frontend/package.json` (a no-dependency placeholder) and `frontend/package-lock.json` (a minimal lockfile with no packages) in `main`, ensuring minimatch 5.1.7 is not present. If the frontend ever needs a real npm dependency that pulls in minimatch transitively, an npm `overrides` field enforcing `>= 9.0.5` should be added.

---

### Files to Modify

| File | Action |
|------|--------|
| `frontend/package.json` | Create — placeholder with no dependencies |
| `frontend/package-lock.json` | Create — minimal lockfileV3 with empty packages |

---

### Implementation Steps

**Step 1 — Create `frontend/package.json`**

```json
{
  "name": "neuralforge-frontend",
  "version": "0.1.0",
  "description": "NeuralForge frontend (placeholder)",
  "license": "MIT",
  "private": true
}
```

No runtime or dev dependencies; therefore no minimatch is pulled in at all.

**Step 2 — Create `frontend/package-lock.json`**

```json
{
  "name": "neuralforge-frontend",
  "version": "0.1.0",
  "lockfileVersion": 3,
  "requires": true,
  "packages": {
    "": {
      "name": "neuralforge-frontend",
      "version": "0.1.0",
      "license": "MIT"
    }
  }
}
```

This is an npm lockfile v3 (Node ≥ 18) with a single root entry and no `node_modules/*` entries. There is no minimatch entry of any version, which eliminates the GHSA-7r86-cg39-jmmj finding.

---

### Testing

1. **OSV/audit check**: Run `npm audit` inside `frontend/` — it should report 0 vulnerabilities since there are no packages.
2. **

### Files Changed
- `frontend/package-lock.json`
- `frontend/package.json`

---
*Created by NeuralWarden Autopilot (event-driven recovery)*