### PR TITLE
feat: implement #-330883025 — Fix 9 agent_sec_002 security findings

### DIFF
--- a/internal/llm/claude.go
+++ b/internal/llm/claude.go
@@ -32,6 +32,9 @@ func (c *ClaudeBackend) Complete(ctx context.Context, req CompletionRequest) (Co
 	if model == "" {
 		model = c.model
 	}
+	// Audit log: record only metadata (backend, agent, model) for attribution.
+	// Request content (System prompt, Messages) is intentionally excluded to
+	// prevent accidental exposure of PII/PHI/PCI or other sensitive data in logs.
 	slog.Debug("llm call", "backend", "claude", "agent", req.AgentName, "model", model)
 
 	maxTokens := int64(req.MaxTokens)

--- a/internal/llm/claude.go
+++ b/internal/llm/claude.go
@@ -3,6 +3,7 @@ package llm
 import (
 	"context"
 	"fmt"
+	"log/slog"
 
 	anthropic "github.com/anthropics/anthropic-sdk-go"
 	"github.com/anthropics/anthropic-sdk-go/option"
@@ -31,6 +32,7 @@ func (c *ClaudeBackend) Complete(ctx context.Context, req CompletionRequest) (Co
 	if model == "" {
 		model = c.model
 	}
+	slog.Debug("llm call", "backend", "claude", "agent", req.AgentName, "model", model)
 
 	maxTokens := int64(req.MaxTokens)
 	if maxTokens == 0 {

--- a/internal/llm/llm.go
+++ b/internal/llm/llm.go
@@ -21,6 +21,7 @@ type CompletionRequest struct {
 	Model       string    `json:"model"`
 	MaxTokens   int       `json:"max_tokens"`
 	Temperature float64   `json:"temperature"`
+	AgentName   string    `json:"agent_name,omitempty"`
 }
 
 type CompletionResponse struct {

--- a/internal/llm/openai.go
+++ b/internal/llm/openai.go
@@ -3,6 +3,7 @@ package llm
 import (
 	"context"
 	"fmt"
+	"log/slog"
 
 	openai "github.com/openai/openai-go"
 	"github.com/openai/openai-go/option"
@@ -31,6 +32,7 @@ func (o *OpenAIBackend) Complete(ctx context.Context, req CompletionRequest) (Co
 	if model == "" {
 		model = o.model
 	}
+	slog.Debug("llm call", "backend", "openai", "agent", req.AgentName, "model", model)
 
 	// Build messages, prepending system message if provided
 	var msgs []openai.ChatCompletionMessageParamUnion

--- a/internal/llm/openai.go
+++ b/internal/llm/openai.go
@@ -32,6 +32,9 @@ func (o *OpenAIBackend) Complete(ctx context.Context, req CompletionRequest) (Co
 	if model == "" {
 		model = o.model
 	}
+	// Audit log: record only metadata (backend, agent, model) for attribution.
+	// Request content (System prompt, Messages) is intentionally excluded to
+	// prevent accidental exposure of PII/PHI/PCI or other sensitive data in logs.
 	slog.Debug("llm call", "backend", "openai", "agent", req.AgentName, "model", model)
 
 	// Build messages, prepending system message if provided

--- a/internal/pipeline/architect.go
+++ b/internal/pipeline/architect.go
@@ -29,7 +29,8 @@ func (s *ArchitectStage) Run(ctx context.Context, state *PipelineState) (StageRe
 	)
 
 	resp, err := s.llm.Complete(ctx, llm.CompletionRequest{
-		System: "You are a software architect creating implementation plans.",
+		AgentName: "architect",
+		System:    "You are a software architect creating implementation plans.",
 		Messages: []llm.Message{
 			{Role: llm.RoleUser, Content: prompt},
 		},

--- a/internal/pipeline/review.go
+++ b/internal/pipeline/review.go
@@ -53,7 +53,8 @@ func (s *ReviewStage) Run(ctx context.Context, state *PipelineState) (StageResul
 	)
 
 	resp, err := s.llm.Complete(ctx, llm.CompletionRequest{
-		System: "You are a code reviewer. Start your response with APPROVE or REQUEST_CHANGES.",
+		AgentName: "review",
+		System:    "You are a code reviewer. Start your response with APPROVE or REQUEST_CHANGES.",
 		Messages: []llm.Message{
 			{Role: llm.RoleUser, Content: prompt},
 		},

--- a/internal/pipeline/security.go
+++ b/internal/pipeline/security.go
@@ -36,7 +36,8 @@ func (s *SecurityStage) Run(ctx context.Context, state *PipelineState) (StageRes
 	)
 
 	resp, err := s.llm.Complete(ctx, llm.CompletionRequest{
-		System: "You are a security reviewer analyzing implementation plans for vulnerabilities.",
+		AgentName: "security",
+		System:    "You are a security reviewer analyzing implementation plans for vulnerabilities.",
 		Messages: []llm.Message{
 			{Role: llm.RoleUser, Content: prompt},
 		},


### PR DESCRIPTION
## Implementation for #-330883025

**Issue:** Fix 9 agent_sec_002 security findings

### Approved Plan
Now I have a complete picture of the codebase. Let me produce the implementation plan.

---

### Approach

The 9 findings all report the same pattern: LLM factory calls without an `agent_name` parameter, preventing audit-log attribution. The Python filenames referenced in the scanner output (`api/llm_sast_scanner.py`, `api/autopilot/review_rules.py`, `pipeline/config.py`, `pipeline/llm_factory.py`) **do not exist** in this Go repository — the equivalent pattern lives in the Go pipeline stages and LLM backends. The fix is to:

1. Add an `AgentName string` field to `CompletionRequest` in the LLM layer.
2. Log it in each backend's `Complete()` method for audit attribution.
3. Populate `AgentName` in every stage that issues LLM calls.

---

### Files to Modify

| File | Change |
|---|---|
| `internal/llm/llm.go` | Add `AgentName string` to `CompletionRequest` |
| `internal/llm/claude.go` | Log `req.AgentName` before API call |
| `internal/llm/openai.go` | Log `req.AgentName` before API call |
| `internal/pipeline/architect.go` | Set `AgentName: "architect"` in `CompletionRequest` |
| `internal/pipeline/security.go` | Set `AgentName: "security"` in `CompletionRequest` |
| `internal/pipeline/review.go` | Set `AgentName: "review"` in `CompletionRequest` |

---

### Implementation Steps

**Step 1 — `internal/llm/llm.go`: Add `AgentName` to request struct**

```go
type CompletionRequest struct {
    System      string    `json:"system"`
    Messages    []Message `json:"messages"`
    Model       string    `json:"model"`
    MaxTokens   int       `json:"max_tokens"`
    Temperature float64   `json:"temperature"`
    AgentName   string    `json:"agent_name,omitempty"` // added
}
```

**Step 2 — `internal/llm/claude.go`: Log agent name before calling the API**

At the top of `Complete()`, before building `params`, add:

```go
import "log/slog"

// in Complete():
slog.Debug("llm call", "backend", "claude", "agent", req.AgentName, "model", model)
```

**Step 3 — `internal/llm/ope

### Files Changed
- `internal/llm/claude.go`
- `internal/llm/llm.go`
- `internal/llm/openai.go`
- `internal/pipeline/architect.go`
- `internal/pipeline/review.go`
- `internal/pipeline/security.go`

---
*Created by NeuralWarden Autopilot (event-driven recovery)*