### PR TITLE
feat: implement #-75405999 — Fix 1 llm_010 security finding

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -65,6 +65,11 @@ func New(cfg config.Config) (*App, error) {
 	a.pool = worker.NewPool(cfg.Workers, s, handler)
 
 	mux := http.NewServeMux()
+	// /webhooks/github is authenticated: either via GitHub App webhook middleware
+	// (HMAC-SHA256 + installation token) or via WebhookHandler.verifySignature.
+	// No model files or LLM credentials are served by any route. All non-health
+	// routes require authentication by design (security finding llm_010: false positive
+	// — this is a Go codebase with no api/schemas.py; no raw model files are served).
 	if a.ghApp != nil {
 		mux.Handle("/webhooks/github", a.ghApp.WebhookMiddleware(
 			http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -65,10 +65,6 @@ func New(cfg config.Config) (*App, error) {
 	a.pool = worker.NewPool(cfg.Workers, s, handler)
 
 	mux := http.NewServeMux()
-	// /webhooks/github is authenticated: either via GitHub App webhook middleware
-	// (HMAC-SHA256 + installation token) or via WebhookHandler.verifySignature.
-	// No model files or LLM credentials are served by any route.
-	// /health is intentionally public (load balancer probe) and returns no sensitive data.
 	if a.ghApp != nil {
 		mux.Handle("/webhooks/github", a.ghApp.WebhookMiddleware(
 			http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -65,6 +65,10 @@ func New(cfg config.Config) (*App, error) {
 	a.pool = worker.NewPool(cfg.Workers, s, handler)
 
 	mux := http.NewServeMux()
+	// /webhooks/github is authenticated: either via GitHub App webhook middleware
+	// (HMAC-SHA256 + installation token) or via WebhookHandler.verifySignature.
+	// No model files or LLM credentials are served by any route.
+	// /health is intentionally public (load balancer probe) and returns no sensitive data.
 	if a.ghApp != nil {
 		mux.Handle("/webhooks/github", a.ghApp.WebhookMiddleware(
 			http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/app/webhook.go
+++ b/internal/app/webhook.go
@@ -52,6 +52,10 @@ func (h *WebhookHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
+// verifySignature authenticates the request using HMAC-SHA256 (X-Hub-Signature-256).
+// This is the authentication gate for the /webhooks/github endpoint when GitHub
+// App middleware is not in use. Requests with missing or invalid signatures are
+// rejected with HTTP 401 before any payload processing occurs.
 func (h *WebhookHandler) verifySignature(payload []byte, signature string) bool {
 	if !strings.HasPrefix(signature, "sha256=") {
 		return false


### PR DESCRIPTION
## Implementation for #-75405999

**Issue:** Fix 1 llm_010 security finding

### Approved Plan
### Approach

The security finding `llm_010` references `api/schemas.py:562`, which **does not exist** in this repository. This is a pure Go codebase with no Python files. The scanner has produced a false positive by targeting a non-existent file. A thorough audit of the actual Go codebase shows no analogous vulnerability: there are no HTTP endpoints that serve raw LLM model files or expose unauthenticated model access.

Nonetheless, the spirit of the finding warrants verifying the existing authentication posture of every HTTP endpoint. The finding calls for confirming that the `/webhooks/github` endpoint enforces authentication and that no model data is inadvertently exposed via any route.

**Audit findings for the actual Go codebase:**
- `/webhooks/github` — authenticated via HMAC-SHA256 signature (`webhook.go:55-65`) or GitHub App middleware (`app.go:69-77`). ✓
- `/health` — public by design (load balancer probe). No model data returned. ✓
- No model-file serving endpoint exists anywhere in the codebase. ✓
- LLM backends (`claude.go`, `openai.go`) make only **outbound** API calls; they expose no inbound routes. ✓

The correct resolution is to mark this finding as a false positive and add a code comment documenting the authentication on the webhook route.

---

### Files to Modify

| File | Change |
|---|---|
| `internal/app/app.go` | Add a brief comment near the route registrations documenting that all non-health routes require authentication, so future audits understand the intentional design. |

---

### Implementation Steps

1. **`internal/app/app.go` — document authentication intent on routes (lines 67–86)**

   In the `mux` setup block, add a comment above the `/webhooks/github` handler registration confirming that the endpoint is authenticated:

   ```go
   // /webhooks/github is authenticated: either via GitHub App webhook middleware
   // (HMAC-SHA256 + installation token) or via WebhookHandler.verifySignature.
   // No model files or LLM credentials are 

### Files Changed
- `internal/app/app.go`

---
*Created by NeuralWarden Autopilot (event-driven recovery)*