### PR TITLE
feat: implement #-633224212 — Fix 1 osv_go_2022_0603 security finding

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -149,7 +149,6 @@ gopkg.in/inf.v0 v0.9.1 h1:73M5CoZyi3ZLMOyDlQh031Cx6N9NDJ2Vvfl76EDAgDc=
 gopkg.in/inf.v0 v0.9.1/go.mod h1:cWUDdTG/fYaXco+Dcufb5Vnc6Gp2YChqWtbxRZE0mXw=
 gopkg.in/yaml.v2 v2.2.8 h1:obN1ZagJSUGI0Ek/LBmuj4SNLPfIny3KsKFopxRdj10=
 gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
-gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 k8s.io/api v0.35.2 h1:tW7mWc2RpxW7HS4CoRXhtYHSzme1PN1UjGHJ1bdrtdw=


### PR DESCRIPTION
## Implementation for #-633224212

**Issue:** Fix 1 osv_go_2022_0603 security finding

### Approved Plan
Now I have enough information to produce the plan.

---

### Approach

The OSV-GO-2022-0603 vulnerability affects `gopkg.in/yaml.v3` prior to `v3.0.0-20220521103104` (fix released as `v3.0.0` stable → `v3.0.1`). The repository's `go.mod` already declares `gopkg.in/yaml.v3 v3.0.1` (the patched version), so no vulnerable code is being compiled.

The scanner flagged `go.sum` because it still contains the old pre-release version's **go.mod hash**:
```
gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:...
```
This entry exists because a transitive dependency's own `go.mod` lists that old pre-release as its minimum requirement. Go's MVS selects `v3.0.1` for the actual build (safe), but retains the old `go.mod` hash in `go.sum` for module graph verification. The fix is to run `go mod tidy` to prune stale graph entries and, if the entry still remains, verify it can't be eliminated (it's a go.mod-only hash, not a source hash, meaning no vulnerable source is downloaded).

### Files to Modify

| File | Change |
|------|--------|
| `go.sum` | Remove stale pre-release `gopkg.in/yaml.v3` go.mod hash entry via `go mod tidy` |
| `go.mod` | No change needed — already on `v3.0.1` |

### Implementation Steps

1. **Run `go mod tidy`** from the repository root to rebuild the `go.sum` based on the current module graph and remove any entries that are no longer needed:
   ```
   go mod tidy
   ```

2. **Verify the old hash is gone** from `go.sum`:
   ```
   grep "3.0.0-20200313102051" go.sum
   # should produce no output
   ```

3. **If the entry persists** (because a first-level dependency's `go.mod` still references that pre-release as its minimum), identify which dependency causes it:
   ```
   go mod graph | grep "gopkg.in/yaml.v3@v3.0.0-20200313102051"
   ```
   Then upgrade that dependency to a version whose `go.mod` references `v3.0.1` or later. For example, if `sigs.k8s.io/yaml` is the culprit, run:
   ```
   go get sigs.k8s.io/yaml@latest
   go mod tidy
   ```

4. **Bu

### Files Changed
- `go.sum`

---
*Created by NeuralWarden Autopilot (event-driven recovery)*