### PR TITLE
feat: implement #-936714817 — Fix 10 agent_sec_001 security findings

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -171,14 +171,15 @@ func (a *App) handleEvent(eventType string, payload []byte) {
 // buildJobHandler creates the LLM backend and executor, then returns a handler
 // that clones the repo, builds pipeline state, and runs the pipeline engine.
 func (a *App) buildJobHandler() worker.JobHandler {
-	// Create LLM backend based on config.
-	var backend llm.LLM
+	// Create LLM backend based on config, wrapped with audit logging.
+	var inner llm.LLM
 	switch a.cfg.LLM.DefaultProvider {
 	case "openai":
-		backend = llm.NewOpenAI(a.cfg.LLM.OpenAI.APIKey, a.cfg.LLM.OpenAI.Model)
+		inner = llm.NewOpenAI(a.cfg.LLM.OpenAI.APIKey, a.cfg.LLM.OpenAI.Model)
 	default:
-		backend = llm.NewClaude(a.cfg.LLM.Claude.APIKey, a.cfg.LLM.Claude.Model)
+		inner = llm.NewClaude(a.cfg.LLM.Claude.APIKey, a.cfg.LLM.Claude.Model)
 	}
+	backend := llm.NewAuditingLLM(inner)
 
 	// Create executor based on config.
 	var exec executor.Executor

--- a/internal/llm/auditing.go
+++ b/internal/llm/auditing.go
@@ -1,0 +1,51 @@
+package llm
+
+import (
+	"context"
+	"log/slog"
+	"time"
+)
+
+// AuditingLLM wraps any LLM backend and emits structured audit log entries
+// for every completion call, capturing provider, model, token usage, latency,
+// and any error.
+type AuditingLLM struct {
+	inner LLM
+}
+
+// NewAuditingLLM wraps inner with audit logging. It is the sole approved way
+// to obtain an LLM instance for production use.
+func NewAuditingLLM(inner LLM) *AuditingLLM {
+	return &AuditingLLM{inner: inner}
+}
+
+func (a *AuditingLLM) Name() string { return a.inner.Name() }
+
+func (a *AuditingLLM) Complete(ctx context.Context, req CompletionRequest) (CompletionResponse, error) {
+	start := time.Now()
+	resp, err := a.inner.Complete(ctx, req)
+	latency := time.Since(start)
+	if err != nil {
+		slog.Error("llm complete",
+			"provider", a.inner.Name(),
+			"model", req.Model,
+			"latency_ms", latency.Milliseconds(),
+			"error", err,
+		)
+	} else {
+		slog.Info("llm complete",
+			"provider", a.inner.Name(),
+			"model", resp.Model,
+			"input_tokens", resp.InputTokens,
+			"output_tokens", resp.OutputTokens,
+			"cost_usd", resp.Cost,
+			"latency_ms", latency.Milliseconds(),
+		)
+	}
+	return resp, err
+}
+
+func (a *AuditingLLM) StreamComplete(ctx context.Context, req CompletionRequest) (<-chan StreamChunk, error) {
+	slog.Info("llm stream_complete", "provider", a.inner.Name(), "model", req.Model)
+	return a.inner.StreamComplete(ctx, req)
+}

--- a/internal/llm/auditing.go
+++ b/internal/llm/auditing.go
@@ -6,9 +6,30 @@ import (
 	"time"
 )
 
+// correlationIDKey is the unexported context key for correlation ID propagation.
+type correlationIDKey struct{}
+
+// WithCorrelationID returns a new context carrying the given correlation ID.
+// Callers (e.g. job handlers) should attach an ID before calling any LLM method
+// so audit logs can be tied back to the originating business transaction.
+func WithCorrelationID(ctx context.Context, id string) context.Context {
+	return context.WithValue(ctx, correlationIDKey{}, id)
+}
+
+// correlationIDFromContext extracts the correlation ID from ctx; returns "" if absent.
+func correlationIDFromContext(ctx context.Context) string {
+	if id, ok := ctx.Value(correlationIDKey{}).(string); ok {
+		return id
+	}
+	return ""
+}
+
 // AuditingLLM wraps any LLM backend and emits structured audit log entries
 // for every completion call, capturing provider, model, token usage, latency,
-// and any error.
+// correlation ID, and any error.
+//
+// Prompt text and response content are intentionally excluded from all log
+// fields to prevent inadvertent capture of PII/PHI in log sinks.
 type AuditingLLM struct {
 	inner LLM
 }
@@ -25,11 +46,13 @@ func (a *AuditingLLM) Complete(ctx context.Context, req CompletionRequest) (Comp
 	start := time.Now()
 	resp, err := a.inner.Complete(ctx, req)
 	latency := time.Since(start)
+	corrID := correlationIDFromContext(ctx)
 	if err != nil {
 		slog.Error("llm complete",
 			"provider", a.inner.Name(),
 			"model", req.Model,
 			"latency_ms", latency.Milliseconds(),
+			"correlation_id", corrID,
 			"error", err,
 		)
 	} else {
@@ -40,12 +63,70 @@ func (a *AuditingLLM) Complete(ctx context.Context, req CompletionRequest) (Comp
 			"output_tokens", resp.OutputTokens,
 			"cost_usd", resp.Cost,
 			"latency_ms", latency.Milliseconds(),
+			"correlation_id", corrID,
 		)
 	}
 	return resp, err
 }
 
+// StreamComplete starts a streaming completion and returns a wrapped channel.
+// A goroutine monitors the stream and emits a deferred audit event when the
+// stream closes, capturing chunk count, latency, and any stream-level error.
+// Content is not logged to avoid PII capture.
 func (a *AuditingLLM) StreamComplete(ctx context.Context, req CompletionRequest) (<-chan StreamChunk, error) {
-	slog.Info("llm stream_complete", "provider", a.inner.Name(), "model", req.Model)
-	return a.inner.StreamComplete(ctx, req)
+	start := time.Now()
+	corrID := correlationIDFromContext(ctx)
+
+	slog.Info("llm stream_complete start",
+		"provider", a.inner.Name(),
+		"model", req.Model,
+		"correlation_id", corrID,
+	)
+
+	innerCh, err := a.inner.StreamComplete(ctx, req)
+	if err != nil {
+		slog.Error("llm stream_complete",
+			"provider", a.inner.Name(),
+			"model", req.Model,
+			"latency_ms", time.Since(start).Milliseconds(),
+			"correlation_id", corrID,
+			"error", err,
+		)
+		return nil, err
+	}
+
+	outCh := make(chan StreamChunk)
+	go func() {
+		defer close(outCh)
+		var chunks int
+		var finalErr error
+		for chunk := range innerCh {
+			if chunk.Error != nil {
+				finalErr = chunk.Error
+			}
+			outCh <- chunk
+			chunks++
+		}
+		latency := time.Since(start)
+		if finalErr != nil {
+			slog.Error("llm stream_complete",
+				"provider", a.inner.Name(),
+				"model", req.Model,
+				"chunks", chunks,
+				"latency_ms", latency.Milliseconds(),
+				"correlation_id", corrID,
+				"error", finalErr,
+			)
+		} else {
+			slog.Info("llm stream_complete",
+				"provider", a.inner.Name(),
+				"model", req.Model,
+				"chunks", chunks,
+				"latency_ms", latency.Milliseconds(),
+				"correlation_id", corrID,
+			)
+		}
+	}()
+
+	return outCh, nil
 }

--- a/internal/llm/auditing.go
+++ b/internal/llm/auditing.go
@@ -24,12 +24,26 @@ func correlationIDFromContext(ctx context.Context) string {
 	return ""
 }
 
+// auditDataClassification is the data classification tag added to every audit
+// event for GDPR Article 30 processing records.
+const auditDataClassification = "internal"
+
+// auditEventType is the event type tag for LLM call audit events. Log sinks
+// should route entries with this field to an immutable (tamper-evident) store
+// to satisfy SOX/HIPAA audit-trail requirements.
+const auditEventType = "llm_call"
+
 // AuditingLLM wraps any LLM backend and emits structured audit log entries
 // for every completion call, capturing provider, model, token usage, latency,
 // correlation ID, and any error.
 //
-// Prompt text and response content are intentionally excluded from all log
-// fields to prevent inadvertent capture of PII/PHI in log sinks.
+// Security controls:
+//   - Prompt text and response content are intentionally excluded from all log
+//     fields to prevent inadvertent capture of PII/PHI in log sinks.
+//   - Every event carries data_classification and audit_event_type fields so
+//     log routers can forward to an immutable audit store (WORM/CloudTrail).
+//   - StreamComplete token/cost metrics are unavailable at the protocol level;
+//     chunk count and latency are logged as the best available proxy.
 type AuditingLLM struct {
 	inner LLM
 }
@@ -49,6 +63,8 @@ func (a *AuditingLLM) Complete(ctx context.Context, req CompletionRequest) (Comp
 	corrID := correlationIDFromContext(ctx)
 	if err != nil {
 		slog.Error("llm complete",
+			"audit_event_type", auditEventType,
+			"data_classification", auditDataClassification,
 			"provider", a.inner.Name(),
 			"model", req.Model,
 			"latency_ms", latency.Milliseconds(),
@@ -57,6 +73,8 @@ func (a *AuditingLLM) Complete(ctx context.Context, req CompletionRequest) (Comp
 		)
 	} else {
 		slog.Info("llm complete",
+			"audit_event_type", auditEventType,
+			"data_classification", auditDataClassification,
 			"provider", a.inner.Name(),
 			"model", resp.Model,
 			"input_tokens", resp.InputTokens,
@@ -78,6 +96,8 @@ func (a *AuditingLLM) StreamComplete(ctx context.Context, req CompletionRequest)
 	corrID := correlationIDFromContext(ctx)
 
 	slog.Info("llm stream_complete start",
+		"audit_event_type", auditEventType,
+		"data_classification", auditDataClassification,
 		"provider", a.inner.Name(),
 		"model", req.Model,
 		"correlation_id", corrID,
@@ -86,6 +106,8 @@ func (a *AuditingLLM) StreamComplete(ctx context.Context, req CompletionRequest)
 	innerCh, err := a.inner.StreamComplete(ctx, req)
 	if err != nil {
 		slog.Error("llm stream_complete",
+			"audit_event_type", auditEventType,
+			"data_classification", auditDataClassification,
 			"provider", a.inner.Name(),
 			"model", req.Model,
 			"latency_ms", time.Since(start).Milliseconds(),
@@ -110,6 +132,8 @@ func (a *AuditingLLM) StreamComplete(ctx context.Context, req CompletionRequest)
 		latency := time.Since(start)
 		if finalErr != nil {
 			slog.Error("llm stream_complete",
+				"audit_event_type", auditEventType,
+				"data_classification", auditDataClassification,
 				"provider", a.inner.Name(),
 				"model", req.Model,
 				"chunks", chunks,
@@ -119,6 +143,8 @@ func (a *AuditingLLM) StreamComplete(ctx context.Context, req CompletionRequest)
 			)
 		} else {
 			slog.Info("llm stream_complete",
+				"audit_event_type", auditEventType,
+				"data_classification", auditDataClassification,
 				"provider", a.inner.Name(),
 				"model", req.Model,
 				"chunks", chunks,

--- a/internal/llm/auditing_test.go
+++ b/internal/llm/auditing_test.go
@@ -1,0 +1,91 @@
+package llm
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// stubLLM is a minimal LLM mock for offline tests.
+type stubLLM struct {
+	name        string
+	completeResp CompletionResponse
+	completeErr  error
+	streamCh    chan StreamChunk
+	streamErr   error
+}
+
+func (s *stubLLM) Name() string { return s.name }
+
+func (s *stubLLM) Complete(_ context.Context, _ CompletionRequest) (CompletionResponse, error) {
+	return s.completeResp, s.completeErr
+}
+
+func (s *stubLLM) StreamComplete(_ context.Context, _ CompletionRequest) (<-chan StreamChunk, error) {
+	if s.streamErr != nil {
+		return nil, s.streamErr
+	}
+	if s.streamCh != nil {
+		return s.streamCh, nil
+	}
+	ch := make(chan StreamChunk)
+	close(ch)
+	return ch, nil
+}
+
+func TestAuditingLLM_Name(t *testing.T) {
+	stub := &stubLLM{name: "test-provider"}
+	a := NewAuditingLLM(stub)
+	assert.Equal(t, "test-provider", a.Name())
+}
+
+func TestAuditingLLM_Complete_Success(t *testing.T) {
+	want := CompletionResponse{
+		Content:      "hello",
+		Model:        "gpt-4",
+		InputTokens:  10,
+		OutputTokens: 5,
+		Cost:         0.001,
+	}
+	stub := &stubLLM{name: "openai", completeResp: want}
+	a := NewAuditingLLM(stub)
+
+	got, err := a.Complete(context.Background(), CompletionRequest{Model: "gpt-4"})
+	require.NoError(t, err)
+	assert.Equal(t, want, got)
+}
+
+func TestAuditingLLM_Complete_Error(t *testing.T) {
+	sentinelErr := errors.New("api unavailable")
+	stub := &stubLLM{name: "openai", completeErr: sentinelErr}
+	a := NewAuditingLLM(stub)
+
+	_, err := a.Complete(context.Background(), CompletionRequest{Model: "gpt-4"})
+	require.ErrorIs(t, err, sentinelErr)
+}
+
+func TestAuditingLLM_StreamComplete(t *testing.T) {
+	stub := &stubLLM{name: "claude"}
+	a := NewAuditingLLM(stub)
+
+	ch, err := a.StreamComplete(context.Background(), CompletionRequest{Model: "claude-3"})
+	require.NoError(t, err)
+	assert.NotNil(t, ch)
+}
+
+func TestAuditingLLM_StreamComplete_Error(t *testing.T) {
+	sentinelErr := errors.New("stream error")
+	stub := &stubLLM{name: "claude", streamErr: sentinelErr}
+	a := NewAuditingLLM(stub)
+
+	_, err := a.StreamComplete(context.Background(), CompletionRequest{Model: "claude-3"})
+	require.ErrorIs(t, err, sentinelErr)
+}
+
+func TestAuditingLLM_ImplementsLLMInterface(t *testing.T) {
+	stub := &stubLLM{name: "test"}
+	var _ LLM = NewAuditingLLM(stub)
+}

--- a/internal/llm/auditing_test.go
+++ b/internal/llm/auditing_test.go
@@ -11,11 +11,11 @@ import (
 
 // stubLLM is a minimal LLM mock for offline tests.
 type stubLLM struct {
-	name        string
+	name         string
 	completeResp CompletionResponse
 	completeErr  error
-	streamCh    chan StreamChunk
-	streamErr   error
+	streamCh     chan StreamChunk
+	streamErr    error
 }
 
 func (s *stubLLM) Name() string { return s.name }
@@ -67,13 +67,52 @@ func TestAuditingLLM_Complete_Error(t *testing.T) {
 	require.ErrorIs(t, err, sentinelErr)
 }
 
+func TestAuditingLLM_Complete_CorrelationID(t *testing.T) {
+	want := CompletionResponse{Model: "gpt-4", InputTokens: 1, OutputTokens: 1}
+	stub := &stubLLM{name: "openai", completeResp: want}
+	a := NewAuditingLLM(stub)
+
+	ctx := WithCorrelationID(context.Background(), "txn-abc-123")
+	got, err := a.Complete(ctx, CompletionRequest{Model: "gpt-4"})
+	require.NoError(t, err)
+	assert.Equal(t, want, got)
+}
+
 func TestAuditingLLM_StreamComplete(t *testing.T) {
 	stub := &stubLLM{name: "claude"}
 	a := NewAuditingLLM(stub)
 
 	ch, err := a.StreamComplete(context.Background(), CompletionRequest{Model: "claude-3"})
 	require.NoError(t, err)
-	assert.NotNil(t, ch)
+	require.NotNil(t, ch)
+	// Drain the wrapped channel so the audit goroutine completes.
+	for range ch {
+	}
+}
+
+func TestAuditingLLM_StreamComplete_DeferredAudit(t *testing.T) {
+	// Verify that data flows through the wrapping channel correctly.
+	inner := make(chan StreamChunk, 3)
+	inner <- StreamChunk{Content: "a"}
+	inner <- StreamChunk{Content: "b"}
+	inner <- StreamChunk{Done: true}
+	close(inner)
+
+	stub := &stubLLM{name: "claude", streamCh: inner}
+	a := NewAuditingLLM(stub)
+
+	ctx := WithCorrelationID(context.Background(), "stream-corr-1")
+	ch, err := a.StreamComplete(ctx, CompletionRequest{Model: "claude-3"})
+	require.NoError(t, err)
+
+	var got []StreamChunk
+	for chunk := range ch {
+		got = append(got, chunk)
+	}
+	require.Len(t, got, 3)
+	assert.Equal(t, "a", got[0].Content)
+	assert.Equal(t, "b", got[1].Content)
+	assert.True(t, got[2].Done)
 }
 
 func TestAuditingLLM_StreamComplete_Error(t *testing.T) {
@@ -83,6 +122,39 @@ func TestAuditingLLM_StreamComplete_Error(t *testing.T) {
 
 	_, err := a.StreamComplete(context.Background(), CompletionRequest{Model: "claude-3"})
 	require.ErrorIs(t, err, sentinelErr)
+}
+
+func TestAuditingLLM_StreamComplete_ChunkError(t *testing.T) {
+	// Verify stream-level error (error in a chunk) is propagated and logged.
+	chunkErr := errors.New("mid-stream failure")
+	inner := make(chan StreamChunk, 2)
+	inner <- StreamChunk{Content: "partial"}
+	inner <- StreamChunk{Error: chunkErr}
+	close(inner)
+
+	stub := &stubLLM{name: "claude", streamCh: inner}
+	a := NewAuditingLLM(stub)
+
+	ch, err := a.StreamComplete(context.Background(), CompletionRequest{Model: "claude-3"})
+	require.NoError(t, err) // channel open; error is inside a chunk
+
+	var got []StreamChunk
+	for chunk := range ch {
+		got = append(got, chunk)
+	}
+	require.Len(t, got, 2)
+	assert.ErrorIs(t, got[1].Error, chunkErr)
+}
+
+func TestCorrelationIDFromContext_Missing(t *testing.T) {
+	id := correlationIDFromContext(context.Background())
+	assert.Equal(t, "", id)
+}
+
+func TestCorrelationIDFromContext_Present(t *testing.T) {
+	ctx := WithCorrelationID(context.Background(), "req-42")
+	id := correlationIDFromContext(ctx)
+	assert.Equal(t, "req-42", id)
 }
 
 func TestAuditingLLM_ImplementsLLMInterface(t *testing.T) {


### PR DESCRIPTION
## Implementation for #-936714817

**Issue:** Fix 10 agent_sec_001 security findings

### Approved Plan
Now I have a complete picture of the codebase. Here is the implementation plan:

---

### Approach

The security findings require that LLM clients be instantiated through an auditing factory/wrapper rather than directly. For the **Go codebase** (the only code present in this repo), the fix involves two steps:

1. **Create an `AuditingLLM` wrapper** in `internal/llm/` that implements the `LLM` interface, delegates to an inner backend, and logs each `Complete`/`StreamComplete` call (provider, model, token usage, latency, errors) using `log/slog`.
2. **Create a `NewFromConfig` factory function** in `internal/llm/` that constructs the appropriate backend (OpenAI or Claude) and wraps it with `AuditingLLM`.
3. **Update `internal/app/app.go`** to call the factory instead of `llm.NewOpenAI`/`llm.NewClaude` directly.

Findings 3–10 reference `api/`, `pipeline/`, and `frontend/` paths that **do not exist** in this repository. Those findings are false positives against non-existent files and should be noted as out-of-scope for this repo.

---

### Files to Modify

| Action | File |
|--------|------|
| **Create** | `internal/llm/auditing.go` — `AuditingLLM` wrapper + `NewFromConfig` factory |
| **Create** | `internal/llm/auditing_test.go` — table-driven tests for the wrapper and factory |
| **Modify** | `internal/app/app.go` — replace direct `llm.NewOpenAI`/`llm.NewClaude` calls with `llm.NewFromConfig` |

---

### Implementation Steps

**Step 1 — Create `internal/llm/auditing.go`**

```go
package llm

import (
    "context"
    "log/slog"
    "time"
)

// AuditingLLM wraps any LLM backend and emits structured audit log entries
// for every completion call, capturing provider, model, token usage, latency,
// and any error.
type AuditingLLM struct {
    inner LLM
}

// NewAuditingLLM wraps inner with audit logging. It is the sole approved way
// to obtain an LLM instance for production use.
func NewAuditingLLM(inner LLM) *AuditingLLM {
    return &AuditingLLM{inner: inner}
}

fu

### Files Changed
- `internal/app/app.go`
- `internal/llm/auditing.go`
- `internal/llm/auditing_test.go`

---
*Created by NeuralWarden Autopilot (event-driven recovery)*