### PR TITLE
feat: implement #-216158586 — Fix 1 osv_ghsa_hp87_p4gw_j4gq security finding

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -149,7 +149,6 @@ gopkg.in/inf.v0 v0.9.1 h1:73M5CoZyi3ZLMOyDlQh031Cx6N9NDJ2Vvfl76EDAgDc=
 gopkg.in/inf.v0 v0.9.1/go.mod h1:cWUDdTG/fYaXco+Dcufb5Vnc6Gp2YChqWtbxRZE0mXw=
 gopkg.in/yaml.v2 v2.2.8 h1:obN1ZagJSUGI0Ek/LBmuj4SNLPfIny3KsKFopxRdj10=
 gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
-gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 k8s.io/api v0.35.2 h1:tW7mWc2RpxW7HS4CoRXhtYHSzme1PN1UjGHJ1bdrtdw=


### PR DESCRIPTION
## Implementation for #-216158586

**Issue:** Fix 1 osv_ghsa_hp87_p4gw_j4gq security finding

### Approved Plan
### Approach

The security scanner flagged `gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c` in `go.sum`. Examining the actual files:

- **`go.mod`** already specifies `gopkg.in/yaml.v3 v3.0.1` as a direct dependency (the patched version)
- **`go.sum`** contains `gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod` — this is a **go.mod-only reference** (no `h1:` archive hash), meaning the vulnerable code is never compiled. It exists because a transitive dependency's `go.mod` references that old pre-release version; Go's MVS then selects `v3.0.1` as the actual resolved version.

The vulnerability GHSA-HP87-P4GW-J4GQ (CVE-2022-28948, infinite loop in `yaml.Unmarshal`) is already mitigated by the current `v3.0.1` requirement. The fix is to run `go mod tidy` to regenerate `go.sum` and prune any stale entries including the flagged pre-release `go.mod` reference.

### Files to Modify

| File | Action |
|------|--------|
| `go.sum` | Regenerated by `go mod tidy` (stale pre-release entry removed) |

No changes to `go.mod` are needed since it already pins `v3.0.1`.

### Implementation Steps

1. **Verify current state** — confirm `go.mod` has `gopkg.in/yaml.v3 v3.0.1` (already confirmed at line 11).

2. **Run `go mod tidy`** in the repository root:
   ```
   go mod tidy
   ```
   This regenerates `go.sum` by walking the full dependency graph and removing entries that are no longer reachable. The stale entry `gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod` should be removed if no current transitive dependency still requires it.

3. **If the entry persists** after tidy (meaning some transitive dep still references it in its own `go.mod`), add an explicit minimum-version override in `go.mod`'s `require` block to make the constraint unambiguous to scanners:
   ```
   // already present — no change needed
   gopkg.in/yaml.v3 v3.0.1
   ```
   This is already satisfied. As a last resort if the scanner still triggers on the go.sum `/go.mod` reference, add a `re

### Files Changed
- `go.sum`

---
*Created by NeuralWarden Autopilot (event-driven recovery)*