### PR TITLE
feat: implement #-269461752 — Fix 1 osv_go_2022_0603 security finding

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -149,7 +149,6 @@ gopkg.in/inf.v0 v0.9.1 h1:73M5CoZyi3ZLMOyDlQh031Cx6N9NDJ2Vvfl76EDAgDc=
 gopkg.in/inf.v0 v0.9.1/go.mod h1:cWUDdTG/fYaXco+Dcufb5Vnc6Gp2YChqWtbxRZE0mXw=
 gopkg.in/yaml.v2 v2.2.8 h1:obN1ZagJSUGI0Ek/LBmuj4SNLPfIny3KsKFopxRdj10=
 gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
-gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 k8s.io/api v0.35.2 h1:tW7mWc2RpxW7HS4CoRXhtYHSzme1PN1UjGHJ1bdrtdw=


### PR DESCRIPTION
## Implementation for #-269461752

**Issue:** Fix 1 osv_go_2022_0603 security finding

### Approved Plan
### Approach

The vulnerable version `gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c` (OSV-2022-0603 — a denial-of-service via deeply nested YAML parsing) appears in `go.sum` only as a `/go.mod` hash entry, meaning it was recorded during module graph resolution as a transitive minimum-version requirement. The actual resolved and compiled version is already `v3.0.1` (patched) as declared in `go.mod`. The fix is to run `go mod tidy` to strip any unnecessary go.sum entries and confirm the old version entry is gone.

### Files to Modify

| File | Change |
|---|---|
| `go.sum` | Remove stale entry for `gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod` via `go mod tidy` |

`go.mod` already has `gopkg.in/yaml.v3 v3.0.1` — no change needed there.

### Implementation Steps

1. **Run `go mod tidy`** from the repo root:
   ```
   go mod tidy
   ```
   This re-resolves the full module graph and removes any `go.sum` entries that are no longer needed (including stale `/go.mod` hashes for old transitive minimums that are superseded by the explicit `v3.0.1` requirement).

2. **Verify the stale entry is gone** from `go.sum`:
   ```
   grep "gopkg.in/yaml.v3 v3.0.0" go.sum
   ```
   Expected: no output.

3. **If the entry persists** after `go mod tidy` (because a transitive dep's own `go.mod` still names that minimum), add an explicit minimum version constraint in `go.mod`'s `require` block to force the entry out of scope:
   ```
   // go.mod indirect block already has v3.0.1, but if needed:
   gopkg.in/yaml.v3 v3.0.1 // indirect — already present, no change
   ```
   In that case, the `/go.mod` hash for the old version is a harmless artifact of Go's module graph construction — the actual source downloaded and compiled is always the MVS-selected `v3.0.1`.

### Testing

```bash
# 1. Tidy and verify build still passes
go mod tidy
make build
make test

# 2. Confirm the old version hash is gone from go.sum
grep "v3.0.0-20200313102051" go.sum  # should return nothing

# 3. 

### Files Changed
- `go.sum`

---
*Created by NeuralWarden Autopilot (event-driven recovery)*