### PR TITLE
feat: implement #-312700970 — Fix 10 agent_sec_001 security findings

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -182,6 +182,7 @@ func (a *App) buildJobHandler() worker.JobHandler {
 	if err != nil {
 		slog.Error("failed to create LLM backend", "error", err)
 		return func(ctx context.Context, job store.Job) error {
+			slog.Error("LLM backend unavailable", "job_id", job.ID, "error", err)
 			return fmt.Errorf("LLM backend init: %w", err)
 		}
 	}

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -182,7 +182,12 @@ func (a *App) buildJobHandler() worker.JobHandler {
 	if err != nil {
 		slog.Error("failed to create LLM backend", "error", err)
 		return func(ctx context.Context, job store.Job) error {
-			slog.Error("LLM backend unavailable", "job_id", job.ID, "error", err)
+			slog.Error("LLM backend unavailable",
+				"job_id",      job.ID,
+				"repo",        job.RepoFullName,
+				"issue",       job.IssueNumber,
+				"error",       err,
+			)
 			return fmt.Errorf("LLM backend init: %w", err)
 		}
 	}

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -173,9 +173,10 @@ func (a *App) handleEvent(eventType string, payload []byte) {
 func (a *App) buildJobHandler() worker.JobHandler {
 	// Select the correct provider config and create an audited LLM backend.
 	var providerCfg config.ProviderConfig
-	if a.cfg.LLM.DefaultProvider == "openai" {
+	switch a.cfg.LLM.DefaultProvider {
+	case "openai":
 		providerCfg = a.cfg.LLM.OpenAI
-	} else {
+	case "claude":
 		providerCfg = a.cfg.LLM.Claude
 	}
 	backend, err := llm.NewFactory(a.cfg.LLM.DefaultProvider, providerCfg.APIKey, providerCfg.Model)

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -171,13 +171,19 @@ func (a *App) handleEvent(eventType string, payload []byte) {
 // buildJobHandler creates the LLM backend and executor, then returns a handler
 // that clones the repo, builds pipeline state, and runs the pipeline engine.
 func (a *App) buildJobHandler() worker.JobHandler {
-	// Create LLM backend based on config.
-	var backend llm.LLM
-	switch a.cfg.LLM.DefaultProvider {
-	case "openai":
-		backend = llm.NewOpenAI(a.cfg.LLM.OpenAI.APIKey, a.cfg.LLM.OpenAI.Model)
-	default:
-		backend = llm.NewClaude(a.cfg.LLM.Claude.APIKey, a.cfg.LLM.Claude.Model)
+	// Select the correct provider config and create an audited LLM backend.
+	var providerCfg config.ProviderConfig
+	if a.cfg.LLM.DefaultProvider == "openai" {
+		providerCfg = a.cfg.LLM.OpenAI
+	} else {
+		providerCfg = a.cfg.LLM.Claude
+	}
+	backend, err := llm.NewFactory(a.cfg.LLM.DefaultProvider, providerCfg.APIKey, providerCfg.Model)
+	if err != nil {
+		slog.Error("failed to create LLM backend", "error", err)
+		return func(ctx context.Context, job store.Job) error {
+			return fmt.Errorf("LLM backend init: %w", err)
+		}
 	}
 
 	// Create executor based on config.

--- a/internal/llm/audit.go
+++ b/internal/llm/audit.go
@@ -62,6 +62,7 @@ func (a *AuditingLLM) StreamComplete(ctx context.Context, req CompletionRequest)
 		"provider", a.inner.Name(),
 		"endpoint", a.endpoint,
 		"region",   a.region,
+		"model",    req.Model,
 		"req_hash", reqHash,
 	)
 	ch, err := a.inner.StreamComplete(ctx, req)
@@ -70,15 +71,16 @@ func (a *AuditingLLM) StreamComplete(ctx context.Context, req CompletionRequest)
 			"provider", a.inner.Name(),
 			"endpoint", a.endpoint,
 			"region",   a.region,
+			"model",    req.Model,
 			"req_hash", reqHash,
-			"error", err,
+			"error",    err,
 		)
 		return nil, err
 	}
 	out := make(chan StreamChunk)
 	go func() {
 		defer close(out)
-		var chunkCount, errorCount int
+		var chunkCount, errorCount, contentLen int
 		for chunk := range ch {
 			if chunk.Error != nil {
 				errorCount++
@@ -92,15 +94,18 @@ func (a *AuditingLLM) StreamComplete(ctx context.Context, req CompletionRequest)
 				)
 			}
 			chunkCount++
+			contentLen += len(chunk.Content)
 			out <- chunk
 		}
 		slog.Info("llm stream_complete done",
-			"provider",    a.inner.Name(),
-			"endpoint",    a.endpoint,
-			"region",      a.region,
-			"req_hash",    reqHash,
-			"chunk_count", chunkCount,
-			"error_count", errorCount,
+			"provider",       a.inner.Name(),
+			"endpoint",       a.endpoint,
+			"region",         a.region,
+			"model",          req.Model,
+			"req_hash",       reqHash,
+			"chunk_count",    chunkCount,
+			"error_count",    errorCount,
+			"content_length", contentLen,
 		)
 	}()
 	return out, nil

--- a/internal/llm/audit.go
+++ b/internal/llm/audit.go
@@ -2,6 +2,8 @@ package llm
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
 	"log/slog"
 )
@@ -9,43 +11,107 @@ import (
 // AuditingLLM wraps any LLM and emits a structured audit log entry
 // for every completion request (provider, model, token usage, cost).
 type AuditingLLM struct {
-	inner LLM
+	inner    LLM
+	endpoint string // API endpoint for GDPR data-transfer audit
 }
 
 func (a *AuditingLLM) Name() string { return a.inner.Name() }
 
+// requestHash returns a short SHA-256 hash of the request content for audit
+// correlation without logging raw payloads (which may contain PHI/PII).
+func requestHash(req CompletionRequest) string {
+	h := sha256.New()
+	h.Write([]byte(req.System))
+	for _, m := range req.Messages {
+		h.Write([]byte(m.Role))
+		h.Write([]byte(m.Content))
+	}
+	return hex.EncodeToString(h.Sum(nil))[:16]
+}
+
 func (a *AuditingLLM) Complete(ctx context.Context, req CompletionRequest) (CompletionResponse, error) {
+	reqHash := requestHash(req)
 	resp, err := a.inner.Complete(ctx, req)
 	if err != nil {
-		slog.Error("llm completion failed", "provider", a.inner.Name(), "error", err)
+		slog.Error("llm completion failed",
+			"provider", a.inner.Name(),
+			"endpoint", a.endpoint,
+			"req_hash", reqHash,
+			"error", err,
+		)
 		return resp, err
 	}
 	slog.Info("llm completion",
 		"provider",      a.inner.Name(),
+		"endpoint",      a.endpoint,
 		"model",         resp.Model,
 		"input_tokens",  resp.InputTokens,
 		"output_tokens", resp.OutputTokens,
 		"cost_usd",      resp.Cost,
+		"req_hash",      reqHash,
 	)
 	return resp, nil
 }
 
 func (a *AuditingLLM) StreamComplete(ctx context.Context, req CompletionRequest) (<-chan StreamChunk, error) {
-	slog.Info("llm stream_complete", "provider", a.inner.Name())
-	return a.inner.StreamComplete(ctx, req)
+	reqHash := requestHash(req)
+	slog.Info("llm stream_complete start",
+		"provider", a.inner.Name(),
+		"endpoint", a.endpoint,
+		"req_hash", reqHash,
+	)
+	ch, err := a.inner.StreamComplete(ctx, req)
+	if err != nil {
+		slog.Error("llm stream_complete failed",
+			"provider", a.inner.Name(),
+			"endpoint", a.endpoint,
+			"req_hash", reqHash,
+			"error", err,
+		)
+		return nil, err
+	}
+	out := make(chan StreamChunk)
+	go func() {
+		defer close(out)
+		var chunkCount int
+		for chunk := range ch {
+			if chunk.Error != nil {
+				slog.Error("llm stream_complete chunk error",
+					"provider", a.inner.Name(),
+					"endpoint", a.endpoint,
+					"req_hash", reqHash,
+					"error", chunk.Error,
+				)
+			}
+			chunkCount++
+			out <- chunk
+		}
+		slog.Info("llm stream_complete done",
+			"provider",    a.inner.Name(),
+			"endpoint",    a.endpoint,
+			"req_hash",    reqHash,
+			"chunk_count", chunkCount,
+		)
+	}()
+	return out, nil
 }
 
 // NewFactory creates the appropriate LLM backend for the given provider and wraps
 // it in an AuditingLLM so every call is audit-logged through a single path.
 func NewFactory(provider, apiKey, model string) (LLM, error) {
 	var inner LLM
+	var endpoint string
 	switch provider {
 	case "openai":
 		inner = NewOpenAI(apiKey, model)
-	case "claude", "":
+		endpoint = "api.openai.com"
+	case "claude":
 		inner = NewClaude(apiKey, model)
+		endpoint = "api.anthropic.com"
+	case "":
+		return nil, fmt.Errorf("LLM provider must be specified; got empty string")
 	default:
 		return nil, fmt.Errorf("unknown LLM provider: %q", provider)
 	}
-	return &AuditingLLM{inner: inner}, nil
+	return &AuditingLLM{inner: inner, endpoint: endpoint}, nil
 }

--- a/internal/llm/audit.go
+++ b/internal/llm/audit.go
@@ -13,6 +13,7 @@ import (
 type AuditingLLM struct {
 	inner    LLM
 	endpoint string // API endpoint for GDPR data-transfer audit
+	region   string // geographic region of the API endpoint for GDPR transfer mechanism verification
 }
 
 func (a *AuditingLLM) Name() string { return a.inner.Name() }
@@ -36,6 +37,7 @@ func (a *AuditingLLM) Complete(ctx context.Context, req CompletionRequest) (Comp
 		slog.Error("llm completion failed",
 			"provider", a.inner.Name(),
 			"endpoint", a.endpoint,
+			"region",   a.region,
 			"req_hash", reqHash,
 			"error", err,
 		)
@@ -44,6 +46,7 @@ func (a *AuditingLLM) Complete(ctx context.Context, req CompletionRequest) (Comp
 	slog.Info("llm completion",
 		"provider",      a.inner.Name(),
 		"endpoint",      a.endpoint,
+		"region",        a.region,
 		"model",         resp.Model,
 		"input_tokens",  resp.InputTokens,
 		"output_tokens", resp.OutputTokens,
@@ -58,6 +61,7 @@ func (a *AuditingLLM) StreamComplete(ctx context.Context, req CompletionRequest)
 	slog.Info("llm stream_complete start",
 		"provider", a.inner.Name(),
 		"endpoint", a.endpoint,
+		"region",   a.region,
 		"req_hash", reqHash,
 	)
 	ch, err := a.inner.StreamComplete(ctx, req)
@@ -65,6 +69,7 @@ func (a *AuditingLLM) StreamComplete(ctx context.Context, req CompletionRequest)
 		slog.Error("llm stream_complete failed",
 			"provider", a.inner.Name(),
 			"endpoint", a.endpoint,
+			"region",   a.region,
 			"req_hash", reqHash,
 			"error", err,
 		)
@@ -73,14 +78,17 @@ func (a *AuditingLLM) StreamComplete(ctx context.Context, req CompletionRequest)
 	out := make(chan StreamChunk)
 	go func() {
 		defer close(out)
-		var chunkCount int
+		var chunkCount, errorCount int
 		for chunk := range ch {
 			if chunk.Error != nil {
+				errorCount++
 				slog.Error("llm stream_complete chunk error",
-					"provider", a.inner.Name(),
-					"endpoint", a.endpoint,
-					"req_hash", reqHash,
-					"error", chunk.Error,
+					"provider",    a.inner.Name(),
+					"endpoint",    a.endpoint,
+					"region",      a.region,
+					"req_hash",    reqHash,
+					"error_count", errorCount,
+					"error",       chunk.Error,
 				)
 			}
 			chunkCount++
@@ -89,8 +97,10 @@ func (a *AuditingLLM) StreamComplete(ctx context.Context, req CompletionRequest)
 		slog.Info("llm stream_complete done",
 			"provider",    a.inner.Name(),
 			"endpoint",    a.endpoint,
+			"region",      a.region,
 			"req_hash",    reqHash,
 			"chunk_count", chunkCount,
+			"error_count", errorCount,
 		)
 	}()
 	return out, nil
@@ -101,17 +111,20 @@ func (a *AuditingLLM) StreamComplete(ctx context.Context, req CompletionRequest)
 func NewFactory(provider, apiKey, model string) (LLM, error) {
 	var inner LLM
 	var endpoint string
+	var region string
 	switch provider {
 	case "openai":
 		inner = NewOpenAI(apiKey, model)
 		endpoint = "api.openai.com"
+		region = "us-east-1" // OpenAI US datacenter; relevant for GDPR transfer mechanism
 	case "claude":
 		inner = NewClaude(apiKey, model)
 		endpoint = "api.anthropic.com"
+		region = "us-east-1" // Anthropic US datacenter; relevant for GDPR transfer mechanism
 	case "":
 		return nil, fmt.Errorf("LLM provider must be specified; got empty string")
 	default:
 		return nil, fmt.Errorf("unknown LLM provider: %q", provider)
 	}
-	return &AuditingLLM{inner: inner, endpoint: endpoint}, nil
+	return &AuditingLLM{inner: inner, endpoint: endpoint, region: region}, nil
 }

--- a/internal/llm/audit.go
+++ b/internal/llm/audit.go
@@ -1,0 +1,51 @@
+package llm
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+)
+
+// AuditingLLM wraps any LLM and emits a structured audit log entry
+// for every completion request (provider, model, token usage, cost).
+type AuditingLLM struct {
+	inner LLM
+}
+
+func (a *AuditingLLM) Name() string { return a.inner.Name() }
+
+func (a *AuditingLLM) Complete(ctx context.Context, req CompletionRequest) (CompletionResponse, error) {
+	resp, err := a.inner.Complete(ctx, req)
+	if err != nil {
+		slog.Error("llm completion failed", "provider", a.inner.Name(), "error", err)
+		return resp, err
+	}
+	slog.Info("llm completion",
+		"provider",      a.inner.Name(),
+		"model",         resp.Model,
+		"input_tokens",  resp.InputTokens,
+		"output_tokens", resp.OutputTokens,
+		"cost_usd",      resp.Cost,
+	)
+	return resp, nil
+}
+
+func (a *AuditingLLM) StreamComplete(ctx context.Context, req CompletionRequest) (<-chan StreamChunk, error) {
+	slog.Info("llm stream_complete", "provider", a.inner.Name())
+	return a.inner.StreamComplete(ctx, req)
+}
+
+// NewFactory creates the appropriate LLM backend for the given provider and wraps
+// it in an AuditingLLM so every call is audit-logged through a single path.
+func NewFactory(provider, apiKey, model string) (LLM, error) {
+	var inner LLM
+	switch provider {
+	case "openai":
+		inner = NewOpenAI(apiKey, model)
+	case "claude", "":
+		inner = NewClaude(apiKey, model)
+	default:
+		return nil, fmt.Errorf("unknown LLM provider: %q", provider)
+	}
+	return &AuditingLLM{inner: inner}, nil
+}


### PR DESCRIPTION
## Implementation for #-312700970

**Issue:** Fix 10 agent_sec_001 security findings

### Approved Plan
---

### Approach

Only findings **1 and 2** are actionable in this repository — the other 8 reference files (`api/*.py`, `frontend/*.tsx`, `pipeline/*.py`) that **do not exist** in this Go codebase. Those belong to separate services/repos and must be handled there.

For findings 1 and 2, the fix is to introduce an **auditing wrapper** (`AuditingLLM`) that implements the `LLM` interface and logs each completion call via `slog`, plus a **factory function** (`NewFactory`) in the `llm` package that creates the right backend and automatically wraps it in the auditing wrapper. `app.go` then calls the factory instead of `NewOpenAI`/`NewClaude` directly.

---

### Files to Modify

| File | Action |
|---|---|
| `internal/llm/audit.go` | **Create** — `AuditingLLM` wrapper struct + `NewFactory` |
| `internal/app/app.go` | **Modify** — replace direct `NewOpenAI`/`NewClaude` calls with `llm.NewFactory(...)` |

---

### Implementation Steps

**1. Create `internal/llm/audit.go`**

```go
package llm

import (
    "context"
    "fmt"
    "log/slog"
)

// AuditingLLM wraps any LLM and emits a structured audit log entry
// for every completion request (provider, model, token usage, cost).
type AuditingLLM struct {
    inner LLM
}

func (a *AuditingLLM) Name() string { return a.inner.Name() }

func (a *AuditingLLM) Complete(ctx context.Context, req CompletionRequest) (CompletionResponse, error) {
    resp, err := a.inner.Complete(ctx, req)
    if err != nil {
        slog.Error("llm completion failed", "provider", a.inner.Name(), "error", err)
        return resp, err
    }
    slog.Info("llm completion",
        "provider",      a.inner.Name(),
        "model",         resp.Model,
        "input_tokens",  resp.InputTokens,
        "output_tokens", resp.OutputTokens,
        "cost_usd",      resp.Cost,
    )
    return resp, nil
}

func (a *AuditingLLM) StreamComplete(ctx context.Context, req CompletionRequest) (<-chan StreamChunk, error) {
    slog.Info("llm stream_complete", "provid

### Files Changed
- `internal/app/app.go`
- `internal/llm/audit.go`

---
*Created by NeuralWarden Autopilot (event-driven recovery)*