### PR TITLE
feat: implement #-217264018 — Fix 50 arch_005 security findings

### DIFF
--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -1,0 +1,192 @@
+package app
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/mandadapu/neuralforge/internal/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func testConfig(t *testing.T) config.Config {
+	t.Helper()
+	dbPath := filepath.Join(t.TempDir(), "test.db")
+	return config.Config{
+		Server:  config.ServerConfig{Port: 0, Host: "127.0.0.1"},
+		Workers: 1,
+		GitHub: config.GitHubConfig{
+			AppID:         0, // no GitHub App auth
+			WebhookSecret: "test-secret",
+		},
+		LLM: config.LLMConfig{
+			DefaultProvider: "claude",
+			Claude:          config.ProviderConfig{APIKey: "sk-test", Model: "claude-sonnet-4-5-20250514"},
+		},
+		Executor: config.ExecutorConfig{
+			DefaultType: "docker",
+			Docker:      config.DockerConfig{Image: "test:latest", Timeout: 30 * time.Minute},
+		},
+		Store: config.StoreConfig{
+			Driver: "sqlite",
+			DSN:    dbPath,
+		},
+		Context: config.ContextConfig{
+			RefreshDays: 7,
+		},
+	}
+}
+
+func TestNew_CreatesAppSuccessfully(t *testing.T) {
+	cfg := testConfig(t)
+
+	app, err := New(cfg)
+	require.NoError(t, err)
+	require.NotNil(t, app)
+
+	// Clean up store
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	_ = app.Shutdown(ctx)
+}
+
+func TestNew_BadDSN_ReturnsError(t *testing.T) {
+	cfg := testConfig(t)
+	cfg.Store.DSN = "/nonexistent/path/db.sqlite"
+
+	_, err := New(cfg)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "open store")
+}
+
+func TestApp_HealthEndpoint(t *testing.T) {
+	cfg := testConfig(t)
+
+	app, err := New(cfg)
+	require.NoError(t, err)
+	defer func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		_ = app.Shutdown(ctx)
+	}()
+
+	req := httptest.NewRequest(http.MethodGet, "/health", nil)
+	rr := httptest.NewRecorder()
+	app.server.Handler.ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusOK, rr.Code)
+	assert.Contains(t, rr.Body.String(), "ok")
+}
+
+func TestApp_HandleEvent_NeuralforgeLabel_CreatesJob(t *testing.T) {
+	cfg := testConfig(t)
+
+	app, err := New(cfg)
+	require.NoError(t, err)
+	defer func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		_ = app.Shutdown(ctx)
+	}()
+
+	payload := []byte(`{
+		"action": "labeled",
+		"label": {"name": "neuralforge"},
+		"issue": {
+			"number": 99,
+			"title": "Test issue",
+			"body": "test body",
+			"user": {"login": "alice"},
+			"labels": [{"name": "neuralforge"}]
+		},
+		"repository": {
+			"full_name": "owner/testrepo",
+			"default_branch": "main",
+			"clone_url": "https://github.com/owner/testrepo.git"
+		}
+	}`)
+
+	app.handleEvent("issues", payload)
+
+	// Verify the job was created in the store
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	job, err := app.store.GetJobByIssue(ctx, "owner/testrepo", 99)
+	require.NoError(t, err)
+	require.NotNil(t, job)
+	assert.Equal(t, "owner/testrepo#99", job.ID)
+	assert.Equal(t, "Test issue", job.IssueTitle)
+}
+
+func TestApp_HandleEvent_OtherLabel_DoesNotCreateJob(t *testing.T) {
+	cfg := testConfig(t)
+
+	app, err := New(cfg)
+	require.NoError(t, err)
+	defer func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		_ = app.Shutdown(ctx)
+	}()
+
+	payload := []byte(`{
+		"action": "labeled",
+		"label": {"name": "bug"},
+		"issue": {
+			"number": 100,
+			"title": "Some issue",
+			"body": "body",
+			"user": {"login": "alice"},
+			"labels": [{"name": "bug"}]
+		},
+		"repository": {
+			"full_name": "owner/testrepo",
+			"default_branch": "main",
+			"clone_url": "https://github.com/owner/testrepo.git"
+		}
+	}`)
+
+	app.handleEvent("issues", payload)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	job, err := app.store.GetJobByIssue(ctx, "owner/testrepo", 100)
+	require.NoError(t, err)
+	assert.Nil(t, job, "job should not be created for non-neuralforge labels")
+}
+
+func TestApp_HandleEvent_UnknownEventType_NoError(t *testing.T) {
+	cfg := testConfig(t)
+
+	app, err := New(cfg)
+	require.NoError(t, err)
+	defer func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		_ = app.Shutdown(ctx)
+	}()
+
+	// Should not panic
+	app.handleEvent("push", []byte(`{"ref":"refs/heads/main"}`))
+}
+
+func TestApp_HandleEvent_InvalidPayload_NoError(t *testing.T) {
+	cfg := testConfig(t)
+
+	app, err := New(cfg)
+	require.NoError(t, err)
+	defer func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		_ = app.Shutdown(ctx)
+	}()
+
+	// Invalid JSON should not panic
+	app.handleEvent("issues", []byte(`{invalid json`))
+}

--- a/internal/github/client_test.go
+++ b/internal/github/client_test.go
@@ -1,0 +1,221 @@
+package github
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	gh "github.com/google/go-github/v60/github"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newTestClient creates a Client pointed at a test HTTP server.
+func newTestClient(t *testing.T, mux *http.ServeMux) (*Client, *httptest.Server) {
+	t.Helper()
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	c := &Client{gh: gh.NewClient(nil)}
+	base, err := url.Parse(srv.URL + "/")
+	require.NoError(t, err)
+	c.gh.BaseURL = base
+	c.gh.UploadURL = base
+
+	return c, srv
+}
+
+func writeJSON(w http.ResponseWriter, status int, v any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(v)
+}
+
+func TestClient_CreatePR(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/repos/owner/repo/pulls", func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+
+		var body map[string]any
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+		assert.Equal(t, "fix: add feature", body["title"])
+
+		writeJSON(w, http.StatusCreated, map[string]any{
+			"number":   42,
+			"html_url": "https://github.com/owner/repo/pull/42",
+		})
+	})
+
+	client, _ := newTestClient(t, mux)
+
+	prNum, prURL, err := client.CreatePR(context.Background(),
+		"owner", "repo", "fix: add feature", "PR body", "feature-branch", "main")
+
+	require.NoError(t, err)
+	assert.Equal(t, 42, prNum)
+	assert.Equal(t, "https://github.com/owner/repo/pull/42", prURL)
+}
+
+func TestClient_CreatePR_Error(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/repos/owner/repo/pulls", func(w http.ResponseWriter, r *http.Request) {
+		writeJSON(w, http.StatusUnprocessableEntity, map[string]any{
+			"message": "Validation failed",
+		})
+	})
+
+	client, _ := newTestClient(t, mux)
+
+	_, _, err := client.CreatePR(context.Background(),
+		"owner", "repo", "title", "body", "head", "base")
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "create PR")
+}
+
+func TestClient_CommentOnIssue(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/repos/owner/repo/issues/5/comments", func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+
+		var body map[string]any
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+		assert.Equal(t, "test comment", body["body"])
+
+		writeJSON(w, http.StatusCreated, map[string]any{
+			"id":   1,
+			"body": "test comment",
+		})
+	})
+
+	client, _ := newTestClient(t, mux)
+
+	err := client.CommentOnIssue(context.Background(), "owner", "repo", 5, "test comment")
+
+	require.NoError(t, err)
+}
+
+func TestClient_CommentOnIssue_Error(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/repos/owner/repo/issues/5/comments", func(w http.ResponseWriter, r *http.Request) {
+		writeJSON(w, http.StatusForbidden, map[string]any{"message": "Forbidden"})
+	})
+
+	client, _ := newTestClient(t, mux)
+
+	err := client.CommentOnIssue(context.Background(), "owner", "repo", 5, "body")
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "comment on issue")
+}
+
+func TestClient_MergePR(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/repos/owner/repo/pulls/7/merge", func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPut, r.Method)
+
+		writeJSON(w, http.StatusOK, map[string]any{
+			"sha":     "abc123",
+			"merged":  true,
+			"message": "Pull Request successfully merged",
+		})
+	})
+
+	client, _ := newTestClient(t, mux)
+
+	err := client.MergePR(context.Background(), "owner", "repo", 7, "merge commit message")
+
+	require.NoError(t, err)
+}
+
+func TestClient_MergePR_Error(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/repos/owner/repo/pulls/7/merge", func(w http.ResponseWriter, r *http.Request) {
+		writeJSON(w, http.StatusMethodNotAllowed, map[string]any{
+			"message": "Pull Request is not mergeable",
+		})
+	})
+
+	client, _ := newTestClient(t, mux)
+
+	err := client.MergePR(context.Background(), "owner", "repo", 7, "message")
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "merge PR")
+}
+
+func TestClient_CreateReview(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/repos/owner/repo/pulls/3/reviews", func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+
+		var body map[string]any
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+		assert.Equal(t, "APPROVE", body["event"])
+
+		writeJSON(w, http.StatusOK, map[string]any{
+			"id":    100,
+			"state": "APPROVED",
+		})
+	})
+
+	client, _ := newTestClient(t, mux)
+
+	err := client.CreateReview(context.Background(), "owner", "repo", 3, "Looks good", "APPROVE")
+
+	require.NoError(t, err)
+}
+
+func TestClient_CreateReview_Error(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/repos/owner/repo/pulls/3/reviews", func(w http.ResponseWriter, r *http.Request) {
+		writeJSON(w, http.StatusForbidden, map[string]any{"message": "Forbidden"})
+	})
+
+	client, _ := newTestClient(t, mux)
+
+	err := client.CreateReview(context.Background(), "owner", "repo", 3, "body", "APPROVE")
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "create review")
+}
+
+func TestClient_GetFileContent(t *testing.T) {
+	// "hello world" base64 encoded
+	mux := http.NewServeMux()
+	mux.HandleFunc("/repos/owner/repo/contents/README.md", func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Equal(t, "main", r.URL.Query().Get("ref"))
+
+		writeJSON(w, http.StatusOK, map[string]any{
+			"type":     "file",
+			"encoding": "base64",
+			"content":  "aGVsbG8gd29ybGQ=\n", // "hello world" base64
+			"name":     "README.md",
+		})
+	})
+
+	client, _ := newTestClient(t, mux)
+
+	content, err := client.GetFileContent(context.Background(), "owner", "repo", "README.md", "main")
+
+	require.NoError(t, err)
+	assert.Equal(t, "hello world", content)
+}
+
+func TestClient_GetFileContent_Error(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/repos/owner/repo/contents/missing.md", func(w http.ResponseWriter, r *http.Request) {
+		writeJSON(w, http.StatusNotFound, map[string]any{"message": "Not Found"})
+	})
+
+	client, _ := newTestClient(t, mux)
+
+	_, err := client.GetFileContent(context.Background(), "owner", "repo", "missing.md", "main")
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "get file content")
+}

--- a/internal/llm/claude_test.go
+++ b/internal/llm/claude_test.go
@@ -1,0 +1,186 @@
+package llm
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	anthropic "github.com/anthropics/anthropic-sdk-go"
+	"github.com/anthropics/anthropic-sdk-go/option"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newClaudeTestServer(t *testing.T, handler http.HandlerFunc) (*ClaudeBackend, *httptest.Server) {
+	t.Helper()
+	srv := httptest.NewServer(handler)
+	t.Cleanup(srv.Close)
+
+	client := anthropic.NewClient(
+		option.WithAPIKey("test-key"),
+		option.WithBaseURL(srv.URL),
+	)
+	backend := &ClaudeBackend{
+		client: client,
+		model:  "claude-sonnet-4-5-20250514",
+	}
+	return backend, srv
+}
+
+func TestClaudeBackend_Name(t *testing.T) {
+	b := &ClaudeBackend{model: "test"}
+	assert.Equal(t, "claude", b.Name())
+}
+
+func TestClaudeBackend_Complete_Success(t *testing.T) {
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		resp := map[string]any{
+			"id":           "msg_test123",
+			"type":         "message",
+			"role":         "assistant",
+			"content":      []map[string]any{{"type": "text", "text": "Hello from Claude!"}},
+			"model":        "claude-sonnet-4-5-20250514",
+			"stop_reason":  "end_turn",
+			"stop_sequence": nil,
+			"usage": map[string]any{
+				"input_tokens":  100,
+				"output_tokens": 50,
+			},
+		}
+		_ = json.NewEncoder(w).Encode(resp)
+	})
+
+	backend, _ := newClaudeTestServer(t, handler)
+
+	resp, err := backend.Complete(context.Background(), CompletionRequest{
+		System: "You are a helpful assistant.",
+		Messages: []Message{
+			{Role: RoleUser, Content: "Say hello"},
+		},
+		MaxTokens:   256,
+		Temperature: 0.5,
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, "Hello from Claude!", resp.Content)
+	assert.Equal(t, 100, resp.InputTokens)
+	assert.Equal(t, 50, resp.OutputTokens)
+	assert.Greater(t, resp.Cost, 0.0)
+}
+
+func TestClaudeBackend_Complete_UsesDefaultModel(t *testing.T) {
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		resp := map[string]any{
+			"id":           "msg_test",
+			"type":         "message",
+			"role":         "assistant",
+			"content":      []map[string]any{{"type": "text", "text": "ok"}},
+			"model":        "claude-sonnet-4-5-20250514",
+			"stop_reason":  "end_turn",
+			"stop_sequence": nil,
+			"usage":        map[string]any{"input_tokens": 10, "output_tokens": 5},
+		}
+		_ = json.NewEncoder(w).Encode(resp)
+	})
+
+	backend, _ := newClaudeTestServer(t, handler)
+
+	// When req.Model is empty, backend.model is used
+	resp, err := backend.Complete(context.Background(), CompletionRequest{
+		Messages: []Message{{Role: RoleUser, Content: "hi"}},
+	})
+
+	require.NoError(t, err)
+	assert.NotEmpty(t, resp.Content)
+}
+
+func TestClaudeBackend_Complete_MultipleTextBlocks(t *testing.T) {
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		resp := map[string]any{
+			"id":           "msg_multi",
+			"type":         "message",
+			"role":         "assistant",
+			"content":      []map[string]any{{"type": "text", "text": "Part 1"}, {"type": "text", "text": "Part 2"}},
+			"model":        "claude-sonnet-4-5-20250514",
+			"stop_reason":  "end_turn",
+			"stop_sequence": nil,
+			"usage":        map[string]any{"input_tokens": 10, "output_tokens": 10},
+		}
+		_ = json.NewEncoder(w).Encode(resp)
+	})
+
+	backend, _ := newClaudeTestServer(t, handler)
+
+	resp, err := backend.Complete(context.Background(), CompletionRequest{
+		Messages: []Message{{Role: RoleUser, Content: "split"}},
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, "Part 1Part 2", resp.Content)
+}
+
+func TestClaudeBackend_Complete_APIError(t *testing.T) {
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusUnauthorized)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"type":  "error",
+			"error": map[string]any{"type": "authentication_error", "message": "Invalid API key"},
+		})
+	})
+
+	backend, _ := newClaudeTestServer(t, handler)
+
+	_, err := backend.Complete(context.Background(), CompletionRequest{
+		Messages: []Message{{Role: RoleUser, Content: "test"}},
+	})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "claude completion failed")
+}
+
+func TestClaudeBackend_StreamComplete_NotImplemented(t *testing.T) {
+	b := &ClaudeBackend{model: "test"}
+	_, err := b.StreamComplete(context.Background(), CompletionRequest{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not implemented")
+}
+
+func TestClaudeBackend_Complete_CostCalculated(t *testing.T) {
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		resp := map[string]any{
+			"id":           "msg_cost",
+			"type":         "message",
+			"role":         "assistant",
+			"content":      []map[string]any{{"type": "text", "text": "response"}},
+			"model":        "claude-sonnet-4-5-20250514",
+			"stop_reason":  "end_turn",
+			"stop_sequence": nil,
+			"usage": map[string]any{
+				"input_tokens":  1000000,
+				"output_tokens": 0,
+			},
+		}
+		_ = json.NewEncoder(w).Encode(resp)
+	})
+
+	backend, _ := newClaudeTestServer(t, handler)
+
+	resp, err := backend.Complete(context.Background(), CompletionRequest{
+		Messages: []Message{{Role: RoleUser, Content: "test"}},
+	})
+
+	require.NoError(t, err)
+	// 1M input tokens at $3.00/M = $3.00
+	assert.InDelta(t, 3.0, resp.Cost, 0.01)
+}

--- a/internal/llm/openai_test.go
+++ b/internal/llm/openai_test.go
@@ -1,0 +1,211 @@
+package llm
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	openai "github.com/openai/openai-go"
+	"github.com/openai/openai-go/option"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newOpenAITestServer(t *testing.T, handler http.HandlerFunc) (*OpenAIBackend, *httptest.Server) {
+	t.Helper()
+	srv := httptest.NewServer(handler)
+	t.Cleanup(srv.Close)
+
+	client := openai.NewClient(
+		option.WithAPIKey("test-key"),
+		option.WithBaseURL(srv.URL),
+	)
+	backend := &OpenAIBackend{
+		client: client,
+		model:  "gpt-4o",
+	}
+	return backend, srv
+}
+
+func TestOpenAIBackend_Name(t *testing.T) {
+	b := &OpenAIBackend{model: "test"}
+	assert.Equal(t, "openai", b.Name())
+}
+
+func TestOpenAIBackend_Complete_Success(t *testing.T) {
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		resp := map[string]any{
+			"id":      "chatcmpl-test123",
+			"object":  "chat.completion",
+			"created": 1677858242,
+			"model":   "gpt-4o",
+			"choices": []map[string]any{
+				{
+					"index": 0,
+					"message": map[string]any{
+						"role":    "assistant",
+						"content": "Hello from OpenAI!",
+					},
+					"finish_reason": "stop",
+				},
+			},
+			"usage": map[string]any{
+				"prompt_tokens":     100,
+				"completion_tokens": 50,
+				"total_tokens":      150,
+			},
+		}
+		_ = json.NewEncoder(w).Encode(resp)
+	})
+
+	backend, _ := newOpenAITestServer(t, handler)
+
+	resp, err := backend.Complete(context.Background(), CompletionRequest{
+		System: "You are a helpful assistant.",
+		Messages: []Message{
+			{Role: RoleUser, Content: "Say hello"},
+		},
+		MaxTokens:   256,
+		Temperature: 0.7,
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, "Hello from OpenAI!", resp.Content)
+	assert.Equal(t, 100, resp.InputTokens)
+	assert.Equal(t, 50, resp.OutputTokens)
+	assert.Greater(t, resp.Cost, 0.0)
+}
+
+func TestOpenAIBackend_Complete_EmptyChoices(t *testing.T) {
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		resp := map[string]any{
+			"id":      "chatcmpl-empty",
+			"object":  "chat.completion",
+			"created": 1677858242,
+			"model":   "gpt-4o",
+			"choices": []map[string]any{},
+			"usage": map[string]any{
+				"prompt_tokens":     10,
+				"completion_tokens": 0,
+				"total_tokens":      10,
+			},
+		}
+		_ = json.NewEncoder(w).Encode(resp)
+	})
+
+	backend, _ := newOpenAITestServer(t, handler)
+
+	resp, err := backend.Complete(context.Background(), CompletionRequest{
+		Messages: []Message{{Role: RoleUser, Content: "test"}},
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, "", resp.Content)
+}
+
+func TestOpenAIBackend_Complete_UsesDefaultModel(t *testing.T) {
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		resp := map[string]any{
+			"id":      "chatcmpl-default",
+			"object":  "chat.completion",
+			"created": 1677858242,
+			"model":   "gpt-4o",
+			"choices": []map[string]any{
+				{
+					"index":   0,
+					"message": map[string]any{"role": "assistant", "content": "ok"},
+					"finish_reason": "stop",
+				},
+			},
+			"usage": map[string]any{
+				"prompt_tokens":     5,
+				"completion_tokens": 2,
+				"total_tokens":      7,
+			},
+		}
+		_ = json.NewEncoder(w).Encode(resp)
+	})
+
+	backend, _ := newOpenAITestServer(t, handler)
+
+	// req.Model is empty, so backend.model ("gpt-4o") is used
+	resp, err := backend.Complete(context.Background(), CompletionRequest{
+		Messages: []Message{{Role: RoleUser, Content: "hi"}},
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, "ok", resp.Content)
+}
+
+func TestOpenAIBackend_Complete_APIError(t *testing.T) {
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusUnauthorized)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"error": map[string]any{
+				"message": "Invalid API key",
+				"type":    "invalid_request_error",
+			},
+		})
+	})
+
+	backend, _ := newOpenAITestServer(t, handler)
+
+	_, err := backend.Complete(context.Background(), CompletionRequest{
+		Messages: []Message{{Role: RoleUser, Content: "test"}},
+	})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "openai completion failed")
+}
+
+func TestOpenAIBackend_StreamComplete_NotImplemented(t *testing.T) {
+	b := &OpenAIBackend{model: "test"}
+	_, err := b.StreamComplete(context.Background(), CompletionRequest{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not implemented")
+}
+
+func TestOpenAIBackend_Complete_CostCalculated(t *testing.T) {
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		resp := map[string]any{
+			"id":      "chatcmpl-cost",
+			"object":  "chat.completion",
+			"created": 1677858242,
+			"model":   "gpt-4o",
+			"choices": []map[string]any{
+				{
+					"index":   0,
+					"message": map[string]any{"role": "assistant", "content": "response"},
+					"finish_reason": "stop",
+				},
+			},
+			"usage": map[string]any{
+				"prompt_tokens":     1000000,
+				"completion_tokens": 0,
+				"total_tokens":      1000000,
+			},
+		}
+		_ = json.NewEncoder(w).Encode(resp)
+	})
+
+	backend, _ := newOpenAITestServer(t, handler)
+
+	resp, err := backend.Complete(context.Background(), CompletionRequest{
+		Messages: []Message{{Role: RoleUser, Content: "test"}},
+	})
+
+	require.NoError(t, err)
+	// 1M prompt tokens for gpt-4o at $2.50/M = $2.50
+	assert.InDelta(t, 2.50, resp.Cost, 0.01)
+}

--- a/internal/pipeline/architect_test.go
+++ b/internal/pipeline/architect_test.go
@@ -1,0 +1,96 @@
+package pipeline
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/mandadapu/neuralforge/internal/llm"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestArchitectStage_Name(t *testing.T) {
+	s := NewArchitectStage(&mockLLM{})
+	assert.Equal(t, "architect", s.Name())
+}
+
+func TestArchitectStage_SetsPlanFromLLMResponse(t *testing.T) {
+	ml := &mockLLM{
+		response: llm.CompletionResponse{
+			Content: "Step 1: modify foo.go\nStep 2: add tests",
+			Cost:    0.05,
+		},
+	}
+
+	s := NewArchitectStage(ml)
+	state := &PipelineState{
+		Issue: GitHubIssue{Number: 42, Title: "Add feature X", Body: "We need feature X"},
+		Repo:  RepoContext{FullName: "owner/repo"},
+	}
+
+	result, err := s.Run(context.Background(), state)
+
+	require.NoError(t, err)
+	assert.Equal(t, StatusPassed, result.Status)
+	assert.Equal(t, "Step 1: modify foo.go\nStep 2: add tests", state.Plan)
+	assert.InDelta(t, 0.05, state.Cost, 0.0001)
+}
+
+func TestArchitectStage_IncludesIssueInPrompt(t *testing.T) {
+	ml := &mockLLM{
+		response: llm.CompletionResponse{Content: "plan"},
+	}
+
+	s := NewArchitectStage(ml)
+	state := &PipelineState{
+		Issue: GitHubIssue{
+			Number: 10,
+			Title:  "My Issue Title",
+			Body:   "My issue body text",
+		},
+		Repo:   RepoContext{FullName: "owner/repo"},
+		Memory: "some codebase context",
+	}
+
+	_, err := s.Run(context.Background(), state)
+
+	require.NoError(t, err)
+	assert.True(t, strings.Contains(ml.lastReq.Messages[0].Content, "My Issue Title"))
+	assert.True(t, strings.Contains(ml.lastReq.Messages[0].Content, "My issue body text"))
+	assert.NotEmpty(t, ml.lastReq.System)
+}
+
+func TestArchitectStage_LLMErrorPropagates(t *testing.T) {
+	ml := &mockLLM{
+		err: errors.New("LLM unavailable"),
+	}
+
+	s := NewArchitectStage(ml)
+	state := &PipelineState{
+		Issue: GitHubIssue{Number: 1, Title: "Test"},
+	}
+
+	_, err := s.Run(context.Background(), state)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "architect llm call")
+}
+
+func TestArchitectStage_AccumulatesCost(t *testing.T) {
+	ml := &mockLLM{
+		response: llm.CompletionResponse{Content: "plan", Cost: 0.10},
+	}
+
+	s := NewArchitectStage(ml)
+	state := &PipelineState{
+		Issue: GitHubIssue{Number: 1, Title: "Test"},
+		Cost:  0.50, // pre-existing cost
+	}
+
+	_, err := s.Run(context.Background(), state)
+
+	require.NoError(t, err)
+	assert.InDelta(t, 0.60, state.Cost, 0.0001)
+}

--- a/internal/pipeline/compliance_test.go
+++ b/internal/pipeline/compliance_test.go
@@ -1,0 +1,145 @@
+package pipeline
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func initComplianceRepo(t *testing.T) (string, string) {
+	t.Helper()
+	dir := t.TempDir()
+
+	cmds := [][]string{
+		{"git", "init", dir},
+		{"git", "-C", dir, "config", "user.email", "test@test.com"},
+		{"git", "-C", dir, "config", "user.name", "Test"},
+	}
+	for _, args := range cmds {
+		require.NoError(t, exec.Command(args[0], args[1:]...).Run())
+	}
+
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "README.md"), []byte("# Test"), 0644))
+	require.NoError(t, exec.Command("git", "-C", dir, "add", ".").Run())
+	require.NoError(t, exec.Command("git", "-C", dir, "commit", "-m", "init").Run())
+
+	out, err := exec.Command("git", "-C", dir, "rev-parse", "--abbrev-ref", "HEAD").Output()
+	require.NoError(t, err)
+
+	// Use whatever branch git init created (main or master depending on git config)
+	branch := strings.TrimSpace(string(out))
+
+	// Create a feature branch with some changes
+	require.NoError(t, exec.Command("git", "-C", dir, "checkout", "-b", "feature").Run())
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "new.go"), []byte("package main\n\nfunc foo() {}\n"), 0644))
+	require.NoError(t, exec.Command("git", "-C", dir, "add", ".").Run())
+	require.NoError(t, exec.Command("git", "-C", dir, "commit", "-m", "add new file").Run())
+
+	return dir, branch
+}
+
+func TestComplianceStage_Name(t *testing.T) {
+	s := NewComplianceStage(1000, 10)
+	assert.Equal(t, "compliance", s.Name())
+}
+
+func TestComplianceStage_NoLocalPath(t *testing.T) {
+	s := NewComplianceStage(1000, 10)
+	state := &PipelineState{}
+
+	result, err := s.Run(context.Background(), state)
+
+	require.NoError(t, err)
+	assert.Equal(t, StatusSkipped, result.Status)
+	assert.Contains(t, result.Output, "no local path")
+}
+
+func TestComplianceStage_WithinLimits(t *testing.T) {
+	dir, defaultBranch := initComplianceRepo(t)
+
+	s := NewComplianceStage(1000, 50)
+	state := &PipelineState{
+		Repo: RepoContext{
+			LocalPath:     dir,
+			DefaultBranch: defaultBranch,
+		},
+	}
+
+	result, err := s.Run(context.Background(), state)
+
+	require.NoError(t, err)
+	assert.Equal(t, StatusPassed, result.Status)
+	require.NotNil(t, state.Compliance)
+	assert.True(t, state.Compliance.Passed)
+	assert.Equal(t, 0, len(state.Compliance.Violations))
+}
+
+func TestComplianceStage_ExceedsDiffLimit(t *testing.T) {
+	dir, defaultBranch := initComplianceRepo(t)
+
+	// maxDiffLines=1 will be exceeded by the added file
+	s := NewComplianceStage(1, 50)
+	state := &PipelineState{
+		Repo: RepoContext{
+			LocalPath:     dir,
+			DefaultBranch: defaultBranch,
+		},
+	}
+
+	result, err := s.Run(context.Background(), state)
+
+	require.NoError(t, err)
+	assert.Equal(t, StatusFailed, result.Status)
+	require.NotNil(t, state.Compliance)
+	assert.False(t, state.Compliance.Passed)
+	assert.NotEmpty(t, state.Compliance.Violations)
+}
+
+func TestComplianceStage_ExceedsFileLimit(t *testing.T) {
+	dir, defaultBranch := initComplianceRepo(t)
+
+	// maxFilesChanged=0 means no limit; set maxFilesChanged=1 and add 2 files
+	// Create a second file change
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "another.go"), []byte("package main\n"), 0644))
+	require.NoError(t, exec.Command("git", "-C", dir, "add", ".").Run())
+	require.NoError(t, exec.Command("git", "-C", dir, "commit", "-m", "add another").Run())
+
+	s := NewComplianceStage(10000, 1)
+	state := &PipelineState{
+		Repo: RepoContext{
+			LocalPath:     dir,
+			DefaultBranch: defaultBranch,
+		},
+	}
+
+	result, err := s.Run(context.Background(), state)
+
+	require.NoError(t, err)
+	assert.Equal(t, StatusFailed, result.Status)
+	require.NotNil(t, state.Compliance)
+	assert.False(t, state.Compliance.Passed)
+}
+
+func TestComplianceStage_ZeroLimitsNoViolation(t *testing.T) {
+	dir, defaultBranch := initComplianceRepo(t)
+
+	// Zero means no limit enforced
+	s := NewComplianceStage(0, 0)
+	state := &PipelineState{
+		Repo: RepoContext{
+			LocalPath:     dir,
+			DefaultBranch: defaultBranch,
+		},
+	}
+
+	result, err := s.Run(context.Background(), state)
+
+	require.NoError(t, err)
+	assert.Equal(t, StatusPassed, result.Status)
+}

--- a/internal/pipeline/deploy_test.go
+++ b/internal/pipeline/deploy_test.go
@@ -1,0 +1,47 @@
+package pipeline
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDeployStage_Name(t *testing.T) {
+	s := NewDeployStage(false)
+	assert.Equal(t, "deploy", s.Name())
+}
+
+func TestDeployStage_Disabled(t *testing.T) {
+	s := NewDeployStage(false)
+	state := &PipelineState{Merged: true}
+
+	result, err := s.Run(context.Background(), state)
+
+	require.NoError(t, err)
+	assert.Equal(t, StatusSkipped, result.Status)
+	assert.Contains(t, result.Output, "disabled")
+}
+
+func TestDeployStage_EnabledButNotMerged(t *testing.T) {
+	s := NewDeployStage(true)
+	state := &PipelineState{Merged: false}
+
+	result, err := s.Run(context.Background(), state)
+
+	require.NoError(t, err)
+	assert.Equal(t, StatusSkipped, result.Status)
+	assert.Contains(t, result.Output, "not merged")
+}
+
+func TestDeployStage_EnabledAndMerged(t *testing.T) {
+	s := NewDeployStage(true)
+	state := &PipelineState{Merged: true}
+
+	result, err := s.Run(context.Background(), state)
+
+	require.NoError(t, err)
+	assert.Equal(t, StatusPassed, result.Status)
+	assert.Contains(t, result.Output, "Deploy triggered")
+}

--- a/internal/pipeline/execute_test.go
+++ b/internal/pipeline/execute_test.go
@@ -1,0 +1,125 @@
+package pipeline
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/mandadapu/neuralforge/internal/executor"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestExecuteStage_Name(t *testing.T) {
+	s := NewExecuteStage(&mockExecutor{}, time.Minute)
+	assert.Equal(t, "execute", s.Name())
+}
+
+func TestExecuteStage_SuccessfulExecution(t *testing.T) {
+	exec := &mockExecutor{
+		result: executor.ExecutorResult{
+			Success:      true,
+			Stdout:       "done",
+			FilesChanged: []string{"main.go", "foo_test.go"},
+		},
+	}
+
+	s := NewExecuteStage(exec, 5*time.Minute)
+	state := &PipelineState{
+		JobID:  "job-1",
+		Issue:  GitHubIssue{Number: 3},
+		Repo:   RepoContext{LocalPath: "/tmp/repo"},
+		Plan:   "implement the feature",
+		Memory: "context here",
+	}
+
+	result, err := s.Run(context.Background(), state)
+
+	require.NoError(t, err)
+	assert.Equal(t, StatusPassed, result.Status)
+	assert.Contains(t, result.Output, "2 files changed")
+	assert.Len(t, state.Changes, 2)
+	assert.Equal(t, "main.go", state.Changes[0].Path)
+	assert.Equal(t, "modified", state.Changes[0].Action)
+}
+
+func TestExecuteStage_PassesJobFieldsToExecutor(t *testing.T) {
+	exec := &mockExecutor{
+		result: executor.ExecutorResult{Success: true},
+	}
+
+	s := NewExecuteStage(exec, 10*time.Minute)
+	state := &PipelineState{
+		JobID:  "my-job",
+		Issue:  GitHubIssue{Number: 42},
+		Repo:   RepoContext{LocalPath: "/repo/path"},
+		Plan:   "my plan",
+		Memory: "my memory",
+	}
+
+	_, err := s.Run(context.Background(), state)
+
+	require.NoError(t, err)
+	assert.Equal(t, "my-job", exec.lastJob.ID)
+	assert.Equal(t, "/repo/path", exec.lastJob.RepoPath)
+	assert.Equal(t, "neuralforge/issue-42", exec.lastJob.Branch)
+	assert.Equal(t, "my plan", exec.lastJob.Prompt)
+	assert.Equal(t, "my memory", exec.lastJob.Context)
+	assert.Equal(t, 10*time.Minute, exec.lastJob.Timeout)
+}
+
+func TestExecuteStage_TimedOut(t *testing.T) {
+	exec := &mockExecutor{
+		result: executor.ExecutorResult{
+			TimedOut: true,
+		},
+	}
+
+	s := NewExecuteStage(exec, time.Minute)
+	state := &PipelineState{
+		Issue: GitHubIssue{Number: 1},
+	}
+
+	result, err := s.Run(context.Background(), state)
+
+	require.NoError(t, err)
+	assert.Equal(t, StatusFailed, result.Status)
+	assert.Contains(t, result.Output, "timed out")
+}
+
+func TestExecuteStage_Failure(t *testing.T) {
+	exec := &mockExecutor{
+		result: executor.ExecutorResult{
+			Success: false,
+			Stderr:  "compilation failed",
+		},
+	}
+
+	s := NewExecuteStage(exec, time.Minute)
+	state := &PipelineState{
+		Issue: GitHubIssue{Number: 1},
+	}
+
+	result, err := s.Run(context.Background(), state)
+
+	require.NoError(t, err)
+	assert.Equal(t, StatusFailed, result.Status)
+	assert.Contains(t, result.Output, "compilation failed")
+}
+
+func TestExecuteStage_ExecutorErrorPropagates(t *testing.T) {
+	exec := &mockExecutor{
+		err: errors.New("executor crashed"),
+	}
+
+	s := NewExecuteStage(exec, time.Minute)
+	state := &PipelineState{
+		Issue: GitHubIssue{Number: 1},
+	}
+
+	_, err := s.Run(context.Background(), state)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "executor run")
+}

--- a/internal/pipeline/merge_test.go
+++ b/internal/pipeline/merge_test.go
@@ -1,0 +1,118 @@
+package pipeline
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMergeStage_Name(t *testing.T) {
+	s := NewMergeStage(&mockGitHubClient{}, true)
+	assert.Equal(t, "merge", s.Name())
+}
+
+func TestMergeStage_AutoMergeDisabled(t *testing.T) {
+	s := NewMergeStage(&mockGitHubClient{}, false)
+	state := &PipelineState{PRNumber: 5}
+
+	result, err := s.Run(context.Background(), state)
+
+	require.NoError(t, err)
+	assert.Equal(t, StatusSkipped, result.Status)
+	assert.Contains(t, result.Output, "Auto-merge disabled")
+}
+
+func TestMergeStage_NoPR(t *testing.T) {
+	s := NewMergeStage(&mockGitHubClient{}, true)
+	state := &PipelineState{PRNumber: 0}
+
+	result, err := s.Run(context.Background(), state)
+
+	require.NoError(t, err)
+	assert.Equal(t, StatusSkipped, result.Status)
+	assert.Contains(t, result.Output, "No PR")
+}
+
+func TestMergeStage_BlockedByRequestChanges(t *testing.T) {
+	var mergeCalled bool
+	client := &mockGitHubClient{
+		mergePRFn: func(ctx context.Context, owner, repo string, number int, message string) error {
+			mergeCalled = true
+			return nil
+		},
+	}
+
+	s := NewMergeStage(client, true)
+	state := &PipelineState{
+		PRNumber:    10,
+		ReviewNotes: "REQUEST_CHANGES\nNeeds more work.",
+		Repo:        RepoContext{FullName: "owner/repo"},
+	}
+
+	result, err := s.Run(context.Background(), state)
+
+	require.NoError(t, err)
+	assert.Equal(t, StatusFailed, result.Status)
+	assert.Contains(t, result.Output, "merge blocked")
+	assert.False(t, mergeCalled, "merge should not have been called")
+}
+
+func TestMergeStage_SuccessfulMerge(t *testing.T) {
+	var capturedNumber int
+	client := &mockGitHubClient{
+		mergePRFn: func(ctx context.Context, owner, repo string, number int, message string) error {
+			capturedNumber = number
+			return nil
+		},
+	}
+
+	s := NewMergeStage(client, true)
+	state := &PipelineState{
+		PRNumber: 7,
+		Issue:    GitHubIssue{Number: 3},
+		Repo:     RepoContext{FullName: "owner/repo"},
+	}
+
+	result, err := s.Run(context.Background(), state)
+
+	require.NoError(t, err)
+	assert.Equal(t, StatusPassed, result.Status)
+	assert.True(t, state.Merged)
+	assert.Equal(t, 7, capturedNumber)
+}
+
+func TestMergeStage_InvalidRepoName(t *testing.T) {
+	s := NewMergeStage(&mockGitHubClient{}, true)
+	state := &PipelineState{
+		PRNumber: 1,
+		Repo:     RepoContext{FullName: "noslash"},
+	}
+
+	_, err := s.Run(context.Background(), state)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid repo name")
+}
+
+func TestMergeStage_GitHubErrorPropagates(t *testing.T) {
+	client := &mockGitHubClient{
+		mergePRFn: func(ctx context.Context, owner, repo string, number int, message string) error {
+			return errors.New("merge conflict")
+		},
+	}
+
+	s := NewMergeStage(client, true)
+	state := &PipelineState{
+		PRNumber: 1,
+		Issue:    GitHubIssue{Number: 1},
+		Repo:     RepoContext{FullName: "o/r"},
+	}
+
+	_, err := s.Run(context.Background(), state)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "merge PR")
+}

--- a/internal/pipeline/pr_test.go
+++ b/internal/pipeline/pr_test.go
@@ -1,0 +1,113 @@
+package pipeline
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPRStage_Name(t *testing.T) {
+	s := NewPRStage(&mockGitHubClient{})
+	assert.Equal(t, "pr", s.Name())
+}
+
+func TestPRStage_CreatesPRWithCorrectFields(t *testing.T) {
+	var capturedTitle, capturedBody, capturedHead, capturedBase string
+	var capturedOwner, capturedRepo string
+
+	client := &mockGitHubClient{
+		createPRFn: func(ctx context.Context, owner, repo, title, body, head, base string) (int, string, error) {
+			capturedOwner = owner
+			capturedRepo = repo
+			capturedTitle = title
+			capturedBody = body
+			capturedHead = head
+			capturedBase = base
+			return 42, "https://github.com/owner/repo/pull/42", nil
+		},
+	}
+
+	s := NewPRStage(client)
+	state := &PipelineState{
+		Issue: GitHubIssue{Number: 7, Title: "Fix the bug"},
+		Repo: RepoContext{
+			FullName:      "owner/repo",
+			DefaultBranch: "main",
+		},
+		Plan: "Step 1: do this\nStep 2: do that",
+		Cost: 0.0123,
+	}
+
+	result, err := s.Run(context.Background(), state)
+
+	require.NoError(t, err)
+	assert.Equal(t, StatusPassed, result.Status)
+	assert.Equal(t, "owner", capturedOwner)
+	assert.Equal(t, "repo", capturedRepo)
+	assert.Contains(t, capturedTitle, "#7")
+	assert.Contains(t, capturedTitle, "Fix the bug")
+	assert.Contains(t, capturedBody, "Automated fix for #7")
+	assert.Equal(t, "neuralforge/issue-7", capturedHead)
+	assert.Equal(t, "main", capturedBase)
+	assert.Equal(t, 42, state.PRNumber)
+	assert.Equal(t, "https://github.com/owner/repo/pull/42", state.PRURL)
+}
+
+func TestPRStage_TitleTruncatedAt72Chars(t *testing.T) {
+	var capturedTitle string
+	client := &mockGitHubClient{
+		createPRFn: func(ctx context.Context, owner, repo, title, body, head, base string) (int, string, error) {
+			capturedTitle = title
+			return 1, "https://github.com/o/r/pull/1", nil
+		},
+	}
+
+	s := NewPRStage(client)
+	state := &PipelineState{
+		Issue: GitHubIssue{
+			Number: 1,
+			Title:  "This is a very long title that should be truncated because it exceeds the limit",
+		},
+		Repo: RepoContext{FullName: "o/r", DefaultBranch: "main"},
+	}
+
+	_, err := s.Run(context.Background(), state)
+
+	require.NoError(t, err)
+	assert.LessOrEqual(t, len(capturedTitle), 72)
+}
+
+func TestPRStage_InvalidRepoName(t *testing.T) {
+	s := NewPRStage(&mockGitHubClient{})
+	state := &PipelineState{
+		Issue: GitHubIssue{Number: 1, Title: "Test"},
+		Repo:  RepoContext{FullName: "invalid-no-slash"},
+	}
+
+	_, err := s.Run(context.Background(), state)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid repo name")
+}
+
+func TestPRStage_GitHubErrorPropagates(t *testing.T) {
+	client := &mockGitHubClient{
+		createPRFn: func(ctx context.Context, owner, repo, title, body, head, base string) (int, string, error) {
+			return 0, "", errors.New("github API error")
+		},
+	}
+
+	s := NewPRStage(client)
+	state := &PipelineState{
+		Issue: GitHubIssue{Number: 1, Title: "Test"},
+		Repo:  RepoContext{FullName: "o/r", DefaultBranch: "main"},
+	}
+
+	_, err := s.Run(context.Background(), state)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "create PR")
+}

--- a/internal/pipeline/review_test.go
+++ b/internal/pipeline/review_test.go
@@ -1,0 +1,145 @@
+package pipeline
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/mandadapu/neuralforge/internal/llm"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestReviewStage_Name(t *testing.T) {
+	s := NewReviewStage(&mockLLM{}, &mockGitHubClient{})
+	assert.Equal(t, "review", s.Name())
+}
+
+func TestReviewStage_SkipsWhenNoPR(t *testing.T) {
+	s := NewReviewStage(&mockLLM{}, &mockGitHubClient{})
+	state := &PipelineState{PRNumber: 0}
+
+	result, err := s.Run(context.Background(), state)
+
+	require.NoError(t, err)
+	assert.Equal(t, StatusSkipped, result.Status)
+}
+
+func TestReviewStage_ApproveWhenLLMSaysApprove(t *testing.T) {
+	ml := &mockLLM{
+		response: llm.CompletionResponse{
+			Content: "APPROVE\nLooks great, well done.",
+			Cost:    0.01,
+		},
+	}
+
+	var capturedEvent string
+	client := &mockGitHubClient{
+		createReviewFn: func(ctx context.Context, owner, repo string, prNumber int, body, event string) error {
+			capturedEvent = event
+			return nil
+		},
+	}
+
+	s := NewReviewStage(ml, client)
+	state := &PipelineState{
+		PRNumber: 5,
+		Issue:    GitHubIssue{Number: 3, Title: "Fix bug"},
+		Repo:     RepoContext{FullName: "owner/repo"},
+	}
+
+	result, err := s.Run(context.Background(), state)
+
+	require.NoError(t, err)
+	assert.Equal(t, StatusPassed, result.Status)
+	assert.Equal(t, "APPROVE", capturedEvent)
+	assert.Equal(t, "APPROVE\nLooks great, well done.", state.ReviewNotes)
+}
+
+func TestReviewStage_RequestChangesWhenLLMSaysRequestChanges(t *testing.T) {
+	ml := &mockLLM{
+		response: llm.CompletionResponse{
+			Content: "REQUEST_CHANGES\nNeeds more error handling.",
+		},
+	}
+
+	var capturedEvent string
+	client := &mockGitHubClient{
+		createReviewFn: func(ctx context.Context, owner, repo string, prNumber int, body, event string) error {
+			capturedEvent = event
+			return nil
+		},
+	}
+
+	s := NewReviewStage(ml, client)
+	state := &PipelineState{
+		PRNumber: 5,
+		Issue:    GitHubIssue{Number: 3, Title: "Fix bug"},
+		Repo:     RepoContext{FullName: "owner/repo"},
+	}
+
+	result, err := s.Run(context.Background(), state)
+
+	require.NoError(t, err)
+	assert.Equal(t, StatusFailed, result.Status)
+	assert.Equal(t, "REQUEST_CHANGES", capturedEvent)
+}
+
+func TestReviewStage_InvalidRepoName(t *testing.T) {
+	ml := &mockLLM{
+		response: llm.CompletionResponse{Content: "APPROVE ok"},
+	}
+
+	s := NewReviewStage(ml, &mockGitHubClient{})
+	state := &PipelineState{
+		PRNumber: 1,
+		Issue:    GitHubIssue{Number: 1, Title: "Test"},
+		Repo:     RepoContext{FullName: "noslash"},
+	}
+
+	_, err := s.Run(context.Background(), state)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid repo name")
+}
+
+func TestReviewStage_LLMErrorPropagates(t *testing.T) {
+	ml := &mockLLM{
+		err: errors.New("LLM error"),
+	}
+
+	s := NewReviewStage(ml, &mockGitHubClient{})
+	state := &PipelineState{
+		PRNumber: 1,
+		Issue:    GitHubIssue{Number: 1, Title: "Test"},
+		Repo:     RepoContext{FullName: "o/r"},
+	}
+
+	_, err := s.Run(context.Background(), state)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "review llm call")
+}
+
+func TestReviewStage_GitHubErrorPropagates(t *testing.T) {
+	ml := &mockLLM{
+		response: llm.CompletionResponse{Content: "APPROVE looks good"},
+	}
+	client := &mockGitHubClient{
+		createReviewFn: func(ctx context.Context, owner, repo string, prNumber int, body, event string) error {
+			return errors.New("github API error")
+		},
+	}
+
+	s := NewReviewStage(ml, client)
+	state := &PipelineState{
+		PRNumber: 1,
+		Issue:    GitHubIssue{Number: 1, Title: "Test"},
+		Repo:     RepoContext{FullName: "o/r"},
+	}
+
+	_, err := s.Run(context.Background(), state)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "post review")
+}

--- a/internal/pipeline/security_test.go
+++ b/internal/pipeline/security_test.go
@@ -1,0 +1,86 @@
+package pipeline
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/mandadapu/neuralforge/internal/llm"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSecurityStage_Name(t *testing.T) {
+	s := NewSecurityStage(&mockLLM{})
+	assert.Equal(t, "security", s.Name())
+}
+
+func TestSecurityStage_SkipsWhenNoPlan(t *testing.T) {
+	s := NewSecurityStage(&mockLLM{})
+	state := &PipelineState{Plan: ""}
+
+	result, err := s.Run(context.Background(), state)
+
+	require.NoError(t, err)
+	assert.Equal(t, StatusSkipped, result.Status)
+	assert.Contains(t, result.Output, "no plan")
+}
+
+func TestSecurityStage_SetsSecurityNotesFromLLMResponse(t *testing.T) {
+	ml := &mockLLM{
+		response: llm.CompletionResponse{
+			Content: "No critical security issues found.",
+			Cost:    0.02,
+		},
+	}
+
+	s := NewSecurityStage(ml)
+	state := &PipelineState{
+		Plan: "Implement new endpoint",
+		Repo: RepoContext{FullName: "owner/repo"},
+	}
+
+	result, err := s.Run(context.Background(), state)
+
+	require.NoError(t, err)
+	assert.Equal(t, StatusPassed, result.Status)
+	assert.Equal(t, "No critical security issues found.", state.SecurityNotes)
+	assert.InDelta(t, 0.02, state.Cost, 0.0001)
+}
+
+func TestSecurityStage_IncludesPlanAndRepoInPrompt(t *testing.T) {
+	ml := &mockLLM{
+		response: llm.CompletionResponse{Content: "ok"},
+	}
+
+	s := NewSecurityStage(ml)
+	state := &PipelineState{
+		Plan: "My implementation plan",
+		Repo: RepoContext{FullName: "myorg/myrepo"},
+	}
+
+	_, err := s.Run(context.Background(), state)
+
+	require.NoError(t, err)
+	prompt := ml.lastReq.Messages[0].Content
+	assert.True(t, strings.Contains(prompt, "My implementation plan"))
+	assert.True(t, strings.Contains(prompt, "myorg/myrepo"))
+}
+
+func TestSecurityStage_LLMErrorPropagates(t *testing.T) {
+	ml := &mockLLM{
+		err: errors.New("LLM failed"),
+	}
+
+	s := NewSecurityStage(ml)
+	state := &PipelineState{
+		Plan: "some plan",
+		Repo: RepoContext{FullName: "o/r"},
+	}
+
+	_, err := s.Run(context.Background(), state)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "security llm call")
+}

--- a/internal/pipeline/testhelpers_test.go
+++ b/internal/pipeline/testhelpers_test.go
@@ -1,0 +1,81 @@
+package pipeline
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/mandadapu/neuralforge/internal/executor"
+	"github.com/mandadapu/neuralforge/internal/llm"
+)
+
+// mockLLM implements llm.LLM for testing pipeline stages.
+type mockLLM struct {
+	response llm.CompletionResponse
+	err      error
+	lastReq  llm.CompletionRequest
+}
+
+func (m *mockLLM) Complete(ctx context.Context, req llm.CompletionRequest) (llm.CompletionResponse, error) {
+	m.lastReq = req
+	return m.response, m.err
+}
+
+func (m *mockLLM) StreamComplete(ctx context.Context, req llm.CompletionRequest) (<-chan llm.StreamChunk, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+
+func (m *mockLLM) Name() string { return "mock" }
+
+// mockGitHubClient implements pipeline.GitHubClient for testing.
+type mockGitHubClient struct {
+	createPRFn    func(ctx context.Context, owner, repo, title, body, head, base string) (int, string, error)
+	createReviewFn func(ctx context.Context, owner, repo string, prNumber int, body, event string) error
+	mergePRFn     func(ctx context.Context, owner, repo string, number int, message string) error
+	commentFn     func(ctx context.Context, owner, repo string, number int, body string) error
+}
+
+func (m *mockGitHubClient) CreatePR(ctx context.Context, owner, repo, title, body, head, base string) (int, string, error) {
+	if m.createPRFn != nil {
+		return m.createPRFn(ctx, owner, repo, title, body, head, base)
+	}
+	return 0, "", nil
+}
+
+func (m *mockGitHubClient) CreateReview(ctx context.Context, owner, repo string, prNumber int, body, event string) error {
+	if m.createReviewFn != nil {
+		return m.createReviewFn(ctx, owner, repo, prNumber, body, event)
+	}
+	return nil
+}
+
+func (m *mockGitHubClient) MergePR(ctx context.Context, owner, repo string, number int, message string) error {
+	if m.mergePRFn != nil {
+		return m.mergePRFn(ctx, owner, repo, number, message)
+	}
+	return nil
+}
+
+func (m *mockGitHubClient) CommentOnIssue(ctx context.Context, owner, repo string, number int, body string) error {
+	if m.commentFn != nil {
+		return m.commentFn(ctx, owner, repo, number, body)
+	}
+	return nil
+}
+
+// mockExecutor implements executor.Executor for testing.
+type mockExecutor struct {
+	result executor.ExecutorResult
+	err    error
+	lastJob executor.ExecutorJob
+}
+
+func (m *mockExecutor) Run(ctx context.Context, job executor.ExecutorJob) (executor.ExecutorResult, error) {
+	m.lastJob = job
+	return m.result, m.err
+}
+
+func (m *mockExecutor) Cleanup(ctx context.Context, jobID string) error {
+	return nil
+}
+
+func (m *mockExecutor) Name() string { return "mock" }

--- a/internal/worker/worker_test.go
+++ b/internal/worker/worker_test.go
@@ -1,0 +1,116 @@
+package worker
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+	"testing"
+
+	"github.com/mandadapu/neuralforge/internal/store"
+	"github.com/stretchr/testify/assert"
+)
+
+// hookStore wraps mockStore with callback hooks for asserting side effects.
+type hookStore struct {
+	mockStore
+	onUpdateJobError func(id, msg string)
+	onCompleteJob    func(id string, status store.JobStatus)
+}
+
+func (h *hookStore) UpdateJobError(ctx context.Context, id string, errMsg string) error {
+	if h.onUpdateJobError != nil {
+		h.onUpdateJobError(id, errMsg)
+	}
+	return nil
+}
+
+func (h *hookStore) CompleteJob(ctx context.Context, id string, status store.JobStatus) error {
+	if h.onCompleteJob != nil {
+		h.onCompleteJob(id, status)
+	}
+	return nil
+}
+
+func TestWorkerProcessesJobsAndExitsOnClose(t *testing.T) {
+	var callCount int32
+	handler := func(ctx context.Context, job store.Job) error {
+		atomic.AddInt32(&callCount, 1)
+		return nil
+	}
+
+	w := &Worker{id: 1, handler: handler, store: &hookStore{}}
+	jobs := make(chan store.Job, 2)
+	jobs <- store.Job{ID: "j1"}
+	jobs <- store.Job{ID: "j2"}
+	close(jobs)
+
+	w.Run(context.Background(), jobs)
+
+	assert.Equal(t, int32(2), atomic.LoadInt32(&callCount))
+}
+
+func TestWorkerRecordsErrorOnHandlerFailure(t *testing.T) {
+	var recordedJobID string
+	hs := &hookStore{
+		onUpdateJobError: func(id, msg string) {
+			recordedJobID = id
+		},
+	}
+
+	handler := func(ctx context.Context, job store.Job) error {
+		return errors.New("handler failed")
+	}
+
+	w := &Worker{id: 2, handler: handler, store: hs}
+	jobs := make(chan store.Job, 1)
+	jobs <- store.Job{ID: "fail-job"}
+	close(jobs)
+
+	w.Run(context.Background(), jobs)
+
+	assert.Equal(t, "fail-job", recordedJobID)
+}
+
+func TestWorkerCompletesJobOnSuccess(t *testing.T) {
+	var completedJobID string
+	hs := &hookStore{
+		onCompleteJob: func(id string, status store.JobStatus) {
+			completedJobID = id
+		},
+	}
+
+	handler := func(ctx context.Context, job store.Job) error {
+		return nil
+	}
+
+	w := &Worker{id: 3, handler: handler, store: hs}
+	jobs := make(chan store.Job, 1)
+	jobs <- store.Job{ID: "success-job"}
+	close(jobs)
+
+	w.Run(context.Background(), jobs)
+
+	assert.Equal(t, "success-job", completedJobID)
+}
+
+func TestWorkerExitsOnContextCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // cancel before any jobs are processed
+
+	var callCount int32
+	handler := func(ctx context.Context, job store.Job) error {
+		atomic.AddInt32(&callCount, 1)
+		return nil
+	}
+
+	w := &Worker{id: 4, handler: handler, store: &hookStore{}}
+	jobs := make(chan store.Job, 2)
+	jobs <- store.Job{ID: "j1"}
+	jobs <- store.Job{ID: "j2"}
+	close(jobs)
+
+	w.Run(ctx, jobs)
+
+	// Worker may process 0, 1, or 2 jobs depending on scheduler timing
+	assert.LessOrEqual(t, atomic.LoadInt32(&callCount), int32(2))
+}


### PR DESCRIPTION
## Implementation for #-217264018

**Issue:** Fix 50 arch_005 security findings

### Approved Plan
### Approach

The issue references 50 arch_005 findings for Python files in an `api/` directory that **do not exist** in this Go codebase. This appears to be a cross-project security scan result mis-filed against the NeuralForge repository. Since the intent is clearly to address missing test coverage, this plan maps the requirement to the **actual untested Go source files** in this codebase.

Of 31 non-test `.go` files in `internal/`, 18 have no corresponding `_test.go`. Files that are pure interface/type definitions (no testable logic) are noted separately. The primary gap is in pipeline stages, LLM backends, the GitHub client, and the app wiring layer.

---

### Files to Modify

**New test files to create:**

| # | Test File | Source File | LOC | Priority |
|---|-----------|-------------|-----|----------|
| 1 | `internal/app/app_test.go` | `app.go` | ~340 | HIGH |
| 2 | `internal/github/client_test.go` | `client.go` | ~84 | MEDIUM |
| 3 | `internal/llm/claude_test.go` | `claude.go` | ~102 | MEDIUM |
| 4 | `internal/llm/openai_test.go` | `openai.go` | ~91 | MEDIUM |
| 5 | `internal/pipeline/architect_test.go` | `architect.go` | ~50 | MEDIUM |
| 6 | `internal/pipeline/compliance_test.go` | `compliance.go` | ~50 | MEDIUM |
| 7 | `internal/pipeline/deploy_test.go` | `deploy.go` | ~35 | LOW |
| 8 | `internal/pipeline/execute_test.go` | `execute.go` | ~50 | MEDIUM |
| 9 | `internal/pipeline/merge_test.go` | `merge.go` | ~50 | MEDIUM |
| 10 | `internal/pipeline/pr_test.go` | `pr.go` | ~49 | LOW |
| 11 | `internal/pipeline/review_test.go` | `review.go` | ~50 | MEDIUM |
| 12 | `internal/pipeline/security_test.go` | `security.go` | ~50 | MEDIUM |
| 13 | `internal/worker/worker_test.go` | `worker.go` | ~36 | LOW |

**Skipped (interface/type-definition-only files — no testable logic):**
- `internal/executor/executor.go` (interface + structs)
- `internal/llm/llm.go` (interface + constants)
- `internal/pipeline/stage.go` (interface + types)
- `internal/pipeline/state.go` (struc

### Files Changed
- `internal/app/app_test.go`
- `internal/github/client_test.go`
- `internal/llm/claude_test.go`
- `internal/llm/openai_test.go`
- `internal/pipeline/architect_test.go`
- `internal/pipeline/compliance_test.go`
- `internal/pipeline/deploy_test.go`
- `internal/pipeline/execute_test.go`
- `internal/pipeline/merge_test.go`
- `internal/pipeline/pr_test.go`
- `internal/pipeline/review_test.go`
- `internal/pipeline/security_test.go`
- `internal/pipeline/testhelpers_test.go`
- `internal/worker/worker_test.go`

---
*Created by NeuralWarden Autopilot Issues Agent*