### PR TITLE
feat: implement #-769263994 — Fix 2 llm_003 security findings

### DIFF
--- a/docs/dismissed-sast-findings.md
+++ b/docs/dismissed-sast-findings.md
@@ -1,0 +1,29 @@
+# Dismissed SAST Findings
+
+This document records SAST findings that have been reviewed and dismissed as not applicable to this repository.
+
+## llm_003 — trust_remote_code=True (Issue #-769263994)
+
+| Field      | Value                                    |
+|------------|------------------------------------------|
+| Severity   | HIGH                                     |
+| Rule       | llm_003                                  |
+| Scan job   | repo:e47b27f                             |
+| Status     | **Dismissed — Not Applicable**           |
+
+### Findings
+
+1. `api/llm_sast_scanner.py:109` — `trust_remote_code=True`
+2. `api/llm_sast_scanner.py:351` — `trust_remote_code=True`
+
+### Reason for Dismissal
+
+The file `api/llm_sast_scanner.py` does not exist in this repository. This is a pure Go codebase with no Python source files. The SAST scan findings are stale or misattributed — they likely originated from a scan of a different repository or a file that has since been removed.
+
+Verification:
+- `find . -name "*.py"` returns no results.
+- `git log --all --full-history -- api/llm_sast_scanner.py` shows no history for this file.
+
+### Action Items
+
+- The autopilot scan job (`repo:e47b27f`) should be reviewed to ensure it is targeting the correct repository and commit. If scanning a stale commit or the wrong fork, the scan configuration should be corrected to prevent future false positives.


### PR DESCRIPTION
## Implementation for #-769263994

**Issue:** Fix 2 llm_003 security findings

### Approved Plan
The file referenced in the issue (`api/llm_sast_scanner.py`) does not exist in this repository. This is a Go codebase with no Python files. The scanner findings reference a Python file that is not part of this project.

---

### Approach

The two security findings reference `trust_remote_code=True` in `api/llm_sast_scanner.py` at lines 109 and 351. This file does not exist anywhere in the repository — the codebase is a pure Go project (`internal/llm/`, etc.) with no Python source files. The SAST scan findings are **stale or misattributed**: they likely originated from a scan of a different repository or a file that has since been deleted.

Since there is nothing to fix in the current codebase, the appropriate action is to document that the findings are not applicable to this repository.

### Files to Modify

None — the target file `api/llm_sast_scanner.py` does not exist in this repository. No code changes are required.

If the file ever existed and was intentionally removed, the fix is already complete. If the autopilot scan is pulling findings from the wrong repo/commit, that is an infrastructure issue with the scan job (job `repo:e47b27f`), not a code issue here.

### Implementation Steps

1. **Verify file absence**: Confirm `api/llm_sast_scanner.py` does not exist (`find . -name "*.py"` returns nothing).
2. **Check git history** for whether the file ever existed and was deleted:
   ```
   git log --all --full-history -- api/llm_sast_scanner.py
   ```
   If already deleted, the security risk is resolved and no further action is needed.
3. **Close/dismiss the findings** in the SAST tracker as "Not Applicable — file does not exist in this repository."
4. If the autopilot scan job `repo:e47b27f` is scanning the wrong commit or repo, investigate and correct the scan configuration so future scans target the correct source.

### Testing

- Run `find . -name "*.py"` to confirm no Python files exist in the repository.
- Run `git log --all --full-history -- api/llm_sast_s

### Files Changed
- `docs/dismissed-sast-findings.md`

---
*Created by NeuralWarden Autopilot (event-driven recovery)*