### PR TITLE
feat: implement #-30140300 — Fix 10 agent_sec_001 security findings

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -175,9 +175,9 @@ func (a *App) buildJobHandler() worker.JobHandler {
 	var backend llm.LLM
 	switch a.cfg.LLM.DefaultProvider {
 	case "openai":
-		backend = llm.NewOpenAI(a.cfg.LLM.OpenAI.APIKey, a.cfg.LLM.OpenAI.Model)
+		backend = llm.NewAudited(llm.NewOpenAI(a.cfg.LLM.OpenAI.APIKey, a.cfg.LLM.OpenAI.Model))
 	default:
-		backend = llm.NewClaude(a.cfg.LLM.Claude.APIKey, a.cfg.LLM.Claude.Model)
+		backend = llm.NewAudited(llm.NewClaude(a.cfg.LLM.Claude.APIKey, a.cfg.LLM.Claude.Model))
 	}
 
 	// Create executor based on config.

--- a/internal/llm/audit.go
+++ b/internal/llm/audit.go
@@ -10,6 +10,12 @@ import (
 // logging of sensitive content that may be embedded in upstream error messages.
 const maxErrLogLen = 200
 
+// maxFieldLen caps arbitrary string fields (e.g. model names) written to audit
+// logs. Provider-assigned model identifiers are typically short (< 50 chars);
+// capping at 100 guards against a misconfigured or malicious value carrying
+// PII/PHI into the log stream.
+const maxFieldLen = 100
+
 // sanitizeError returns a safe, length-bounded string for audit log entries.
 // Full error messages can embed request/response content containing PII/PHI;
 // truncating removes that risk while preserving enough context for diagnostics.
@@ -17,6 +23,23 @@ func sanitizeError(err error) string {
 	s := err.Error()
 	if len(s) > maxErrLogLen {
 		return s[:maxErrLogLen] + "...[truncated]"
+	}
+	return s
+}
+
+// sanitizeField truncates an arbitrary string field to maxFieldLen characters
+// before it is written to an audit log entry. Use this for every string field
+// whose value originates from an external system (e.g. provider-returned model
+// name) to prevent accidental logging of PII/PHI embedded in that value.
+//
+// Log governance note: audit log entries produced by AuditedLLM contain only
+// numeric metrics and sanitized string identifiers — never request/response
+// content. Operators are responsible for configuring log retention, access
+// controls, and encryption at rest/in transit to satisfy applicable compliance
+// requirements (SOX, HIPAA, etc.).
+func sanitizeField(s string) string {
+	if len(s) > maxFieldLen {
+		return s[:maxFieldLen] + "...[truncated]"
 	}
 	return s
 }
@@ -49,7 +72,9 @@ func (a *AuditedLLM) Complete(ctx context.Context, req CompletionRequest) (Compl
 
 	attrs := []any{
 		"provider", a.inner.Name(),
-		"model", resp.Model,
+		// sanitizeField guards against a provider returning an unexpectedly long
+		// or PII-bearing model identifier.
+		"model", sanitizeField(resp.Model),
 		"input_tokens", resp.InputTokens,
 		"output_tokens", resp.OutputTokens,
 		"cost_usd", resp.Cost,
@@ -66,15 +91,24 @@ func (a *AuditedLLM) Complete(ctx context.Context, req CompletionRequest) (Compl
 }
 
 // StreamComplete wraps the inner stream and emits an audit log entry when the
-// stream completes (Done=true) or encounters an error, recording latency and
-// total content bytes as a proxy for token usage (streaming APIs do not always
-// surface per-chunk token counts).
+// stream completes (Done=true) or encounters an error. The entry records:
+// provider, requested model (sanitized), latency, total content bytes, and —
+// when the Done chunk carries them — input/output token counts and cost.
+//
+// Note: many streaming APIs do not surface per-chunk token counts; in that case
+// total_content_bytes serves as a proxy for usage. Operators who require exact
+// token accounting should prefer Complete over StreamComplete.
 func (a *AuditedLLM) StreamComplete(ctx context.Context, req CompletionRequest) (<-chan StreamChunk, error) {
 	start := time.Now()
+	// Capture the requested model name now; it is available from the request
+	// regardless of whether the provider echoes it back in stream chunks.
+	requestedModel := sanitizeField(req.Model)
+
 	innerCh, err := a.inner.StreamComplete(ctx, req)
 	if err != nil {
 		slog.WarnContext(ctx, "llm.StreamComplete failed",
 			"provider", a.inner.Name(),
+			"model", requestedModel,
 			"error", sanitizeError(err),
 		)
 		return nil, err
@@ -91,6 +125,7 @@ func (a *AuditedLLM) StreamComplete(ctx context.Context, req CompletionRequest) 
 				elapsed := time.Since(start)
 				attrs := []any{
 					"provider", a.inner.Name(),
+					"model", requestedModel,
 					"latency_ms", elapsed.Milliseconds(),
 					"total_content_bytes", totalBytes,
 				}

--- a/internal/llm/audit.go
+++ b/internal/llm/audit.go
@@ -1,0 +1,51 @@
+package llm
+
+import (
+	"context"
+	"log/slog"
+	"time"
+)
+
+// AuditedLLM wraps an LLM backend and emits structured audit log entries
+// for every completion request: provider, model, token counts, cost, and latency.
+type AuditedLLM struct {
+	inner LLM
+}
+
+// NewAudited returns an LLM that wraps inner with audit logging.
+// All call sites must go through this function instead of instantiating
+// backends directly, satisfying the auditing factory requirement.
+func NewAudited(inner LLM) LLM {
+	return &AuditedLLM{inner: inner}
+}
+
+func (a *AuditedLLM) Name() string {
+	return a.inner.Name()
+}
+
+func (a *AuditedLLM) Complete(ctx context.Context, req CompletionRequest) (CompletionResponse, error) {
+	start := time.Now()
+	resp, err := a.inner.Complete(ctx, req)
+	elapsed := time.Since(start)
+
+	attrs := []any{
+		"provider", a.inner.Name(),
+		"model", resp.Model,
+		"input_tokens", resp.InputTokens,
+		"output_tokens", resp.OutputTokens,
+		"cost_usd", resp.Cost,
+		"latency_ms", elapsed.Milliseconds(),
+	}
+	if err != nil {
+		attrs = append(attrs, "error", err)
+		slog.WarnContext(ctx, "llm.Complete failed", attrs...)
+	} else {
+		slog.InfoContext(ctx, "llm.Complete", attrs...)
+	}
+	return resp, err
+}
+
+func (a *AuditedLLM) StreamComplete(ctx context.Context, req CompletionRequest) (<-chan StreamChunk, error) {
+	slog.InfoContext(ctx, "llm.StreamComplete", "provider", a.inner.Name())
+	return a.inner.StreamComplete(ctx, req)
+}

--- a/internal/llm/audit.go
+++ b/internal/llm/audit.go
@@ -6,8 +6,27 @@ import (
 	"time"
 )
 
+// maxErrLogLen caps error strings written to audit logs to prevent accidental
+// logging of sensitive content that may be embedded in upstream error messages.
+const maxErrLogLen = 200
+
+// sanitizeError returns a safe, length-bounded string for audit log entries.
+// Full error messages can embed request/response content containing PII/PHI;
+// truncating removes that risk while preserving enough context for diagnostics.
+func sanitizeError(err error) string {
+	s := err.Error()
+	if len(s) > maxErrLogLen {
+		return s[:maxErrLogLen] + "...[truncated]"
+	}
+	return s
+}
+
 // AuditedLLM wraps an LLM backend and emits structured audit log entries
 // for every completion request: provider, model, token counts, cost, and latency.
+//
+// Privacy note: logged fields are limited to provider-assigned identifiers
+// (model name), numeric metrics (tokens, cost, latency), and truncated error
+// strings. Request/response content is never logged.
 type AuditedLLM struct {
 	inner LLM
 }
@@ -37,7 +56,8 @@ func (a *AuditedLLM) Complete(ctx context.Context, req CompletionRequest) (Compl
 		"latency_ms", elapsed.Milliseconds(),
 	}
 	if err != nil {
-		attrs = append(attrs, "error", err)
+		// Use sanitizeError to avoid logging PII/PHI that may appear in error messages.
+		attrs = append(attrs, "error", sanitizeError(err))
 		slog.WarnContext(ctx, "llm.Complete failed", attrs...)
 	} else {
 		slog.InfoContext(ctx, "llm.Complete", attrs...)
@@ -45,7 +65,43 @@ func (a *AuditedLLM) Complete(ctx context.Context, req CompletionRequest) (Compl
 	return resp, err
 }
 
+// StreamComplete wraps the inner stream and emits an audit log entry when the
+// stream completes (Done=true) or encounters an error, recording latency and
+// total content bytes as a proxy for token usage (streaming APIs do not always
+// surface per-chunk token counts).
 func (a *AuditedLLM) StreamComplete(ctx context.Context, req CompletionRequest) (<-chan StreamChunk, error) {
-	slog.InfoContext(ctx, "llm.StreamComplete", "provider", a.inner.Name())
-	return a.inner.StreamComplete(ctx, req)
+	start := time.Now()
+	innerCh, err := a.inner.StreamComplete(ctx, req)
+	if err != nil {
+		slog.WarnContext(ctx, "llm.StreamComplete failed",
+			"provider", a.inner.Name(),
+			"error", sanitizeError(err),
+		)
+		return nil, err
+	}
+
+	out := make(chan StreamChunk)
+	go func() {
+		defer close(out)
+		var totalBytes int
+		for chunk := range innerCh {
+			totalBytes += len(chunk.Content)
+			out <- chunk
+			if chunk.Done || chunk.Error != nil {
+				elapsed := time.Since(start)
+				attrs := []any{
+					"provider", a.inner.Name(),
+					"latency_ms", elapsed.Milliseconds(),
+					"total_content_bytes", totalBytes,
+				}
+				if chunk.Error != nil {
+					attrs = append(attrs, "error", sanitizeError(chunk.Error))
+					slog.WarnContext(ctx, "llm.StreamComplete failed", attrs...)
+				} else {
+					slog.InfoContext(ctx, "llm.StreamComplete", attrs...)
+				}
+			}
+		}
+	}()
+	return out, nil
 }

--- a/internal/llm/audit_test.go
+++ b/internal/llm/audit_test.go
@@ -100,3 +100,43 @@ func TestSanitizeError_truncates(t *testing.T) {
 	assert.LessOrEqual(t, len(result), maxErrLogLen+len("...[truncated]"))
 	assert.Contains(t, result, "[truncated]")
 }
+
+func TestSanitizeField_short(t *testing.T) {
+	assert.Equal(t, "gpt-4", sanitizeField("gpt-4"))
+}
+
+func TestSanitizeField_truncates(t *testing.T) {
+	long := strings.Repeat("m", 200)
+	result := sanitizeField(long)
+	assert.LessOrEqual(t, len(result), maxFieldLen+len("...[truncated]"))
+	assert.Contains(t, result, "[truncated]")
+}
+
+func TestAuditedLLM_Complete_sanitizesModel(t *testing.T) {
+	longModel := strings.Repeat("m", 200)
+	want := CompletionResponse{
+		Content: "hi",
+		Model:   longModel,
+	}
+	mock := &mockLLM{name: "openai", resp: want}
+	audited := NewAudited(mock)
+
+	// Verify the response passes through unchanged (model field is not mutated).
+	got, err := audited.Complete(context.Background(), CompletionRequest{})
+	require.NoError(t, err)
+	assert.Equal(t, longModel, got.Model, "response model must not be mutated by audit wrapper")
+}
+
+func TestAuditedLLM_StreamComplete_logsModel(t *testing.T) {
+	ch := make(chan StreamChunk, 1)
+	ch <- StreamChunk{Content: "done", Done: true}
+	close(ch)
+
+	mock := &mockLLM{name: "claude", streamCh: ch}
+	audited := NewAudited(mock)
+
+	got, err := audited.StreamComplete(context.Background(), CompletionRequest{Model: "claude-3"})
+	require.NoError(t, err)
+	for range got {
+	}
+}

--- a/internal/llm/audit_test.go
+++ b/internal/llm/audit_test.go
@@ -3,6 +3,7 @@ package llm
 import (
 	"context"
 	"errors"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -59,11 +60,43 @@ func TestAuditedLLM_Complete_error(t *testing.T) {
 }
 
 func TestAuditedLLM_StreamComplete(t *testing.T) {
-	ch := make(chan StreamChunk)
+	ch := make(chan StreamChunk, 2)
+	ch <- StreamChunk{Content: "hello "}
+	ch <- StreamChunk{Content: "world", Done: true}
+	close(ch)
+
 	mock := &mockLLM{name: "claude", streamCh: ch}
 	audited := NewAudited(mock)
 
 	got, err := audited.StreamComplete(context.Background(), CompletionRequest{})
 	require.NoError(t, err)
-	assert.Equal(t, ch, got)
+
+	var chunks []StreamChunk
+	for c := range got {
+		chunks = append(chunks, c)
+	}
+	require.Len(t, chunks, 2)
+	assert.Equal(t, "hello ", chunks[0].Content)
+	assert.True(t, chunks[1].Done)
+}
+
+func TestAuditedLLM_StreamComplete_error(t *testing.T) {
+	sentinel := errors.New("stream error")
+	mock := &mockLLM{name: "claude", streamErr: sentinel}
+	audited := NewAudited(mock)
+
+	_, err := audited.StreamComplete(context.Background(), CompletionRequest{})
+	assert.ErrorIs(t, err, sentinel)
+}
+
+func TestSanitizeError_short(t *testing.T) {
+	err := errors.New("short error")
+	assert.Equal(t, "short error", sanitizeError(err))
+}
+
+func TestSanitizeError_truncates(t *testing.T) {
+	long := strings.Repeat("x", 300)
+	result := sanitizeError(errors.New(long))
+	assert.LessOrEqual(t, len(result), maxErrLogLen+len("...[truncated]"))
+	assert.Contains(t, result, "[truncated]")
 }

--- a/internal/llm/audit_test.go
+++ b/internal/llm/audit_test.go
@@ -1,0 +1,69 @@
+package llm
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type mockLLM struct {
+	name     string
+	resp     CompletionResponse
+	err      error
+	streamCh <-chan StreamChunk
+	streamErr error
+}
+
+func (m *mockLLM) Name() string { return m.name }
+
+func (m *mockLLM) Complete(_ context.Context, _ CompletionRequest) (CompletionResponse, error) {
+	return m.resp, m.err
+}
+
+func (m *mockLLM) StreamComplete(_ context.Context, _ CompletionRequest) (<-chan StreamChunk, error) {
+	return m.streamCh, m.streamErr
+}
+
+func TestAuditedLLM_Name(t *testing.T) {
+	mock := &mockLLM{name: "test-provider"}
+	audited := NewAudited(mock)
+	assert.Equal(t, "test-provider", audited.Name())
+}
+
+func TestAuditedLLM_Complete_success(t *testing.T) {
+	want := CompletionResponse{
+		Content:      "hello",
+		Model:        "gpt-4",
+		InputTokens:  10,
+		OutputTokens: 5,
+		Cost:         0.001,
+	}
+	mock := &mockLLM{name: "openai", resp: want}
+	audited := NewAudited(mock)
+
+	got, err := audited.Complete(context.Background(), CompletionRequest{})
+	require.NoError(t, err)
+	assert.Equal(t, want, got)
+}
+
+func TestAuditedLLM_Complete_error(t *testing.T) {
+	sentinel := errors.New("upstream error")
+	mock := &mockLLM{name: "openai", err: sentinel}
+	audited := NewAudited(mock)
+
+	_, err := audited.Complete(context.Background(), CompletionRequest{})
+	assert.ErrorIs(t, err, sentinel)
+}
+
+func TestAuditedLLM_StreamComplete(t *testing.T) {
+	ch := make(chan StreamChunk)
+	mock := &mockLLM{name: "claude", streamCh: ch}
+	audited := NewAudited(mock)
+
+	got, err := audited.StreamComplete(context.Background(), CompletionRequest{})
+	require.NoError(t, err)
+	assert.Equal(t, ch, got)
+}


### PR DESCRIPTION
## Implementation for #-30140300

**Issue:** Fix 10 agent_sec_001 security findings

### Approved Plan
Now I have enough context. The Python/TypeScript files (findings 3–10) do not exist in this repository — this is a Go-only project. Only findings 1 and 2 are actionable here. Let me write the plan.

---

### Approach

Introduce an `AuditedLLM` wrapper in the `internal/llm` package that implements the `LLM` interface and logs audit events (provider, model, token usage, cost, latency) around every `Complete` and `StreamComplete` call via `slog`. Then update `app.go` to wrap every backend through this auditing layer before use, so no LLM client is used un-audited.

Findings 3–10 reference files (`api/`, `frontend/`, `pipeline/`) that do not exist in this repository. They are out of scope for this PR.

---

### Files to Modify

| File | Action |
|---|---|
| `internal/llm/audit.go` | **Create** — `AuditedLLM` wrapper + `NewAudited` factory |
| `internal/app/app.go` | **Modify** — wrap backends with `llm.NewAudited(backend)` at lines 178–181 |

---

### Implementation Steps

**Step 1 — Create `internal/llm/audit.go`**

```go
package llm

import (
    "context"
    "log/slog"
    "time"
)

// AuditedLLM wraps an LLM backend and emits structured audit log entries
// for every completion request: provider, model, token counts, cost, and latency.
type AuditedLLM struct {
    inner LLM
}

// NewAudited returns an LLM that wraps inner with audit logging.
// All call sites must go through this function instead of instantiating
// backends directly, satisfying the auditing factory requirement.
func NewAudited(inner LLM) LLM {
    return &AuditedLLM{inner: inner}
}

func (a *AuditedLLM) Name() string {
    return a.inner.Name()
}

func (a *AuditedLLM) Complete(ctx context.Context, req CompletionRequest) (CompletionResponse, error) {
    start := time.Now()
    resp, err := a.inner.Complete(ctx, req)
    elapsed := time.Since(start)

    attrs := []any{
        "provider", a.inner.Name(),
        "model", resp.Model,
        "input_tokens", resp.InputTokens,
        "output_tokens"

### Files Changed
- `internal/app/app.go`
- `internal/llm/audit.go`
- `internal/llm/audit_test.go`

---
*Created by NeuralWarden Autopilot (event-driven recovery)*