### PR TITLE
feat: implement #-857727274 — Fix 1 osv_go_2022_0603 security finding

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -149,7 +149,6 @@ gopkg.in/inf.v0 v0.9.1 h1:73M5CoZyi3ZLMOyDlQh031Cx6N9NDJ2Vvfl76EDAgDc=
 gopkg.in/inf.v0 v0.9.1/go.mod h1:cWUDdTG/fYaXco+Dcufb5Vnc6Gp2YChqWtbxRZE0mXw=
 gopkg.in/yaml.v2 v2.2.8 h1:obN1ZagJSUGI0Ek/LBmuj4SNLPfIny3KsKFopxRdj10=
 gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
-gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 k8s.io/api v0.35.2 h1:tW7mWc2RpxW7HS4CoRXhtYHSzme1PN1UjGHJ1bdrtdw=


### PR DESCRIPTION
## Implementation for #-857727274

**Issue:** Fix 1 osv_go_2022_0603 security finding

### Approved Plan
### Approach

The OSV finding `GO-2022-0603` flags `gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c` detected in `go.sum`. The current `go.mod` already declares `gopkg.in/yaml.v3 v3.0.1` (the patched version) as a direct dependency, so no application code is compiled against the vulnerable version. The go.sum entry for the old version is a go.mod-only checksum (`/go.mod` suffix, no `h1:` source hash), meaning Go only fetched that version's module manifest during dependency graph resolution — not its source code. Running `go mod tidy` will regenerate `go.sum` and remove any stale entries no longer required by the module graph.

---

### Files to Modify

| File | Change |
|------|--------|
| `go.sum` | Regenerated by `go mod tidy` — removes the stale `v3.0.0-20200313102051-9f266ea9e77c/go.mod` entry |

`go.mod` requires no changes — `gopkg.in/yaml.v3 v3.0.1` is already the declared version.

---

### Implementation Steps

1. **Verify current state** — Confirm the vulnerable version only appears as a go.mod-only entry in `go.sum` (no `h1:` source hash), confirming no compiled code uses it:
   ```
   grep 'yaml.v3' go.sum
   # Expected: only /go.mod entries for the old version, h1: entry only for v3.0.1
   ```

2. **Run `go mod tidy`** to regenerate `go.sum`, pruning entries that are no longer reachable in the module graph:
   ```bash
   go mod tidy
   ```

3. **Verify removal** — Confirm the stale entry is gone from `go.sum`:
   ```bash
   grep 'yaml.v3' go.sum
   # Should only show v3.0.1 entries
   ```

4. **If the entry persists** after `go mod tidy` (meaning a transitive dependency still references it for graph resolution), add an explicit `require` override with `go get` to ensure MVS always selects v3.0.1 or later — though given the direct dep is already v3.0.1, this should be unnecessary.

---

### Testing

- Run `make build` to confirm the project still compiles cleanly.
- Run `make test` to verify no regressions.
- Run `go mod verify` to confirm all module

### Files Changed
- `go.sum`

---
*Created by NeuralWarden Autopilot (event-driven recovery)*