### PR TITLE
feat: implement #-441681439 — Fix 2 agent_sec_001 security findings

### DIFF
--- a/internal/llm/audit.go
+++ b/internal/llm/audit.go
@@ -1,0 +1,51 @@
+package llm
+
+import (
+	"context"
+	"log/slog"
+	"time"
+)
+
+// auditedLLM wraps any LLM and emits a structured audit log entry for every
+// Complete call, recording provider, model, token counts, cost, latency, and
+// any error. This satisfies the security requirement that all LLM interactions
+// pass through an auditing layer.
+type auditedLLM struct {
+	inner LLM
+}
+
+// NewAuditedLLM returns an LLM that wraps inner and audit-logs every Complete call.
+func NewAuditedLLM(inner LLM) LLM {
+	return &auditedLLM{inner: inner}
+}
+
+func (a *auditedLLM) Name() string {
+	return a.inner.Name()
+}
+
+func (a *auditedLLM) Complete(ctx context.Context, req CompletionRequest) (CompletionResponse, error) {
+	start := time.Now()
+	resp, err := a.inner.Complete(ctx, req)
+	latency := time.Since(start)
+
+	attrs := []any{
+		"provider", a.inner.Name(),
+		"model", resp.Model,
+		"input_tokens", resp.InputTokens,
+		"output_tokens", resp.OutputTokens,
+		"cost_usd", resp.Cost,
+		"latency_ms", latency.Milliseconds(),
+	}
+	if err != nil {
+		attrs = append(attrs, "error", err)
+		slog.Error("llm audit: complete failed", attrs...)
+	} else {
+		slog.Info("llm audit: complete", attrs...)
+	}
+
+	return resp, err
+}
+
+func (a *auditedLLM) StreamComplete(ctx context.Context, req CompletionRequest) (<-chan StreamChunk, error) {
+	return a.inner.StreamComplete(ctx, req)
+}

--- a/internal/llm/openai.go
+++ b/internal/llm/openai.go
@@ -14,12 +14,13 @@ type OpenAIBackend struct {
 	model  string
 }
 
-func NewOpenAI(apiKey, model string) *OpenAIBackend {
+func NewOpenAI(apiKey, model string) LLM {
 	client := openai.NewClient(option.WithAPIKey(apiKey))
-	return &OpenAIBackend{
+	backend := &OpenAIBackend{
 		client: client,
 		model:  model,
 	}
+	return NewAuditedLLM(backend)
 }
 
 func (o *OpenAIBackend) Name() string {


### PR DESCRIPTION
## Implementation for #-441681439

**Issue:** Fix 2 agent_sec_001 security findings

### Approved Plan
---

### Approach

Introduce an auditing wrapper (`auditedLLM`) in the `llm` package that implements the `LLM` interface and logs every `Complete` call (provider, model, token counts, cost, latency, errors). Then modify `NewOpenAI` to return this audited wrapper instead of the raw backend — so all callers (including `app.go:178`) automatically get auditing without any changes at the call site.

This keeps changes minimal and localised to the `llm` package. `app.go` needs no changes because `llm.NewOpenAI(...)` will transparently return an audited backend.

---

### Files to Modify

| File | Action |
|------|--------|
| `internal/llm/audit.go` | **Create** — auditing wrapper struct + `NewAuditedLLM` factory |
| `internal/llm/openai.go` | **Modify** — `NewOpenAI` wraps the raw backend via `NewAuditedLLM` before returning |

`internal/app/app.go` does **not** need changes: once `NewOpenAI` returns an audited `LLM`, line 178 already goes through the auditing factory.

---

### Implementation Steps

**Step 1 — Create `internal/llm/audit.go`**

```go
package llm

import (
    "context"
    "log/slog"
    "time"
)

// auditedLLM wraps any LLM and emits a structured audit log entry for every
// Complete call, recording provider, model, token counts, cost, latency, and
// any error. This satisfies the security requirement that all LLM interactions
// pass through an auditing layer.
type auditedLLM struct {
    inner LLM
}

// NewAuditedLLM returns an LLM that wraps inner and audit-logs every Complete call.
func NewAuditedLLM(inner LLM) LLM {
    return &auditedLLM{inner: inner}
}

func (a *auditedLLM) Name() string {
    return a.inner.Name()
}

func (a *auditedLLM) Complete(ctx context.Context, req CompletionRequest) (CompletionResponse, error) {
    start := time.Now()
    resp, err := a.inner.Complete(ctx, req)
    latency := time.Since(start)

    attrs := []any{
        "provider", a.inner.Name(),
        "model", resp.Model,
        "input_tokens", resp.InputTokens,
  

### Files Changed
- `internal/llm/audit.go`
- `internal/llm/openai.go`

---
*Created by NeuralWarden Autopilot (event-driven recovery)*