### PR TITLE
feat: implement #-761213143 — Fix 1 osv_go_2022_0603 security finding

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -149,7 +149,6 @@ gopkg.in/inf.v0 v0.9.1 h1:73M5CoZyi3ZLMOyDlQh031Cx6N9NDJ2Vvfl76EDAgDc=
 gopkg.in/inf.v0 v0.9.1/go.mod h1:cWUDdTG/fYaXco+Dcufb5Vnc6Gp2YChqWtbxRZE0mXw=
 gopkg.in/yaml.v2 v2.2.8 h1:obN1ZagJSUGI0Ek/LBmuj4SNLPfIny3KsKFopxRdj10=
 gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
-gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 k8s.io/api v0.35.2 h1:tW7mWc2RpxW7HS4CoRXhtYHSzme1PN1UjGHJ1bdrtdw=


### PR DESCRIPTION
## Implementation for #-761213143

**Issue:** Fix 1 osv_go_2022_0603 security finding

### Approved Plan
Now I have a clear picture of the issue. Let me produce the implementation plan.

---

### Approach

The security scanner flagged `gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c` found in `go.sum`. OSV-GO-2022-0603 is an infinite-loop (DoS) vulnerability in `gopkg.in/yaml.v3` versions prior to `v3.0.0` (fixed in `v3.0.1`).

**The good news:** `go.mod` already declares `gopkg.in/yaml.v3 v3.0.1` as a direct dependency — the patched version. The vulnerable pre-release version appears only as a `/go.mod`-only hash in `go.sum` (line 152), which is a stale resolution artifact from when Go's MVS consulted that version's `go.mod` while resolving the dependency graph. No vulnerable code is compiled into the binary.

The fix is to remove this stale entry from `go.sum` by running `go mod tidy`, and optionally adding a `require` minimum-version pin to prevent regression.

---

### Files to Modify

| File | Change |
|------|--------|
| `go.sum` | Remove stale `gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod` hash entry (via `go mod tidy`) |

`go.mod` requires no changes — it already pins `v3.0.1`.

---

### Implementation Steps

1. **Run `go mod tidy`** in the repository root. This re-resolves the dependency graph and rewrites `go.sum` to include only hashes for versions actually needed, dropping the stale `v3.0.0-20200313102051-9f266ea9e77c/go.mod` entry on line 152 of `go.sum`.

2. **Verify the vulnerable hash is gone** from `go.sum`:
   ```
   grep "yaml.v3" go.sum
   ```
   Expected result: only `v3.0.1` entries remain.

3. **Confirm `go.mod` still pins the safe version** (`v3.0.1`) and that `internal/config/repoconfig.go` still compiles correctly.

---

### Testing

- `make build` — confirms the binary still compiles with `gopkg.in/yaml.v3 v3.0.1`.
- `make test` — confirms existing tests pass after the `go.sum` update.
- `grep "3.0.0-20200313102051" go.sum` should return no results.
- Re-running the security scanner (`osv-scanner` or equivalent) against the 

### Files Changed
- `go.sum`

---
*Created by NeuralWarden Autopilot (event-driven recovery)*