### PR TITLE
feat: implement #-845857078 — Fix 1 osv_ghsa_hp87_p4gw_j4gq security finding

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -149,7 +149,6 @@ gopkg.in/inf.v0 v0.9.1 h1:73M5CoZyi3ZLMOyDlQh031Cx6N9NDJ2Vvfl76EDAgDc=
 gopkg.in/inf.v0 v0.9.1/go.mod h1:cWUDdTG/fYaXco+Dcufb5Vnc6Gp2YChqWtbxRZE0mXw=
 gopkg.in/yaml.v2 v2.2.8 h1:obN1ZagJSUGI0Ek/LBmuj4SNLPfIny3KsKFopxRdj10=
 gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
-gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 k8s.io/api v0.35.2 h1:tW7mWc2RpxW7HS4CoRXhtYHSzme1PN1UjGHJ1bdrtdw=


### PR DESCRIPTION
## Implementation for #-845857078

**Issue:** Fix 1 osv_ghsa_hp87_p4gw_j4gq security finding

### Approved Plan
### Approach

The OSV scanner flagged `go.sum` line 152 referencing `gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod`. This is a **go.mod-only hash** (no `h1:` source hash), meaning the vulnerable version's **source code was never downloaded or built** — only its go.mod was fetched during Go's Minimum Version Selection (MVS) graph traversal because some transitive dependency declared it as a requirement.

The direct dependency in `go.mod` is already `v3.0.1` (the patched version), and the compiled binary uses only v3.0.1. The fix is to run `go mod tidy` to prune stale go.sum entries, and if the entry persists, identify and upgrade the transitive dependency that still references the old version in its own go.mod.

---

### Files to Modify

| File | Change |
|------|--------|
| `go.sum` | Remove stale entry for `v3.0.0-20200313102051-9f266ea9e77c/go.mod` (via `go mod tidy`) |
| `go.mod` | Possibly add/update an indirect `require` to force the transitive chain away from the old version, if tidy alone is insufficient |

---

### Implementation Steps

1. **Run `go mod tidy`** from the repository root:
   ```
   go mod tidy
   ```
   This re-resolves the module graph, downloads only what is needed, and rewrites `go.sum` to contain only hashes for modules actually required. If no transitive dependency still references the pre-release version, the entry on go.sum line 152 will be removed automatically.

2. **Verify the result** by checking go.sum:
   ```
   grep "yaml.v3" go.sum
   ```
   Expected outcome — only the patched version remains:
   ```
   gopkg.in/yaml.v3 v3.0.1 h1:fxVm/...
   gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7...
   ```

3. **If the stale entry persists after tidy**, a transitive dependency still declares the old pre-release in its own go.mod. Identify it:
   ```
   go mod graph | grep "yaml.v3@v3.0.0-20200313102051"
   ```
   Then pin the offending package to a version whose go.mod no longer references the old yaml.v3 pre-release. Add an expli

### Files Changed
- `go.sum`

---
*Created by NeuralWarden Autopilot (event-driven recovery)*