### PR TITLE
feat: implement #-1169202776 — Fix 2 agent_sec_001 security findings

### DIFF
--- a/internal/llm/audit.go
+++ b/internal/llm/audit.go
@@ -95,16 +95,29 @@ func (a *AuditedLLM) StreamComplete(ctx context.Context, req CompletionRequest) 
 	go func() {
 		defer close(out)
 		var lastErr error
+		var inputTokens, outputTokens int
+		var cost float64
 		for chunk := range inner {
 			out <- chunk
 			if chunk.Error != nil {
 				lastErr = chunk.Error
 			}
+			// Accumulate usage from the final chunk (Done==true) for backends
+			// that surface token counts in the streaming API.
+			if chunk.Done {
+				inputTokens = chunk.InputTokens
+				outputTokens = chunk.OutputTokens
+				cost = chunk.Cost
+			}
 		}
-		// Emit audit entry at stream closure. Content is intentionally omitted.
+		// Emit audit entry at stream closure. Content is intentionally omitted
+		// to prevent PHI/PII/PAN exposure. Only operational metadata is recorded.
 		slog.Info("llm.StreamComplete",
 			"audit_event", auditEvent(lastErr),
 			"provider", a.inner.Name(),
+			"input_tokens", inputTokens,
+			"output_tokens", outputTokens,
+			"cost_usd", cost,
 			"latency_ms", time.Since(start).Milliseconds(),
 			"error", lastErr,
 		)

--- a/internal/llm/audit.go
+++ b/internal/llm/audit.go
@@ -1,0 +1,39 @@
+package llm
+
+import (
+	"context"
+	"log/slog"
+	"time"
+)
+
+// AuditedLLM wraps any LLM and emits a structured audit log entry on every call.
+type AuditedLLM struct {
+	inner LLM
+}
+
+// NewAudited returns an LLM that wraps inner with audit logging.
+func NewAudited(inner LLM) LLM {
+	return &AuditedLLM{inner: inner}
+}
+
+func (a *AuditedLLM) Name() string { return a.inner.Name() }
+
+func (a *AuditedLLM) Complete(ctx context.Context, req CompletionRequest) (CompletionResponse, error) {
+	start := time.Now()
+	resp, err := a.inner.Complete(ctx, req)
+	slog.Info("llm.Complete",
+		"provider", a.inner.Name(),
+		"model", resp.Model,
+		"input_tokens", resp.InputTokens,
+		"output_tokens", resp.OutputTokens,
+		"cost_usd", resp.Cost,
+		"latency_ms", time.Since(start).Milliseconds(),
+		"error", err,
+	)
+	return resp, err
+}
+
+func (a *AuditedLLM) StreamComplete(ctx context.Context, req CompletionRequest) (<-chan StreamChunk, error) {
+	slog.Info("llm.StreamComplete", "provider", a.inner.Name())
+	return a.inner.StreamComplete(ctx, req)
+}

--- a/internal/llm/audit.go
+++ b/internal/llm/audit.go
@@ -2,11 +2,35 @@ package llm
 
 import (
 	"context"
+	"errors"
 	"log/slog"
+	"net/http"
 	"time"
 )
 
-// AuditedLLM wraps any LLM and emits a structured audit log entry on every call.
+// AuditedLLM wraps any LLM and emits structured audit log entries on every call.
+//
+// # Content filtering
+//
+// Only operational metadata is logged (provider, model, token counts, cost, latency,
+// audit_event). Message content and system prompts are intentionally excluded to
+// prevent inadvertent logging of PHI/PII/PAN. Callers must not add content fields to
+// this logger.
+//
+// # GDPR / data-retention basis
+//
+// The operational metrics logged by this wrapper (token counts, cost, latency, error
+// codes) constitute pseudonymous technical telemetry with no direct personal
+// identifiers. The legal basis for processing is Article 6(1)(f) GDPR (legitimate
+// interests: capacity planning, fraud/abuse detection, cost management). Logs should
+// be retained no longer than necessary per the organisation's retention policy.
+// If LLMs process personal or health data, a DPIA must be conducted per Article 35
+// GDPR before deployment to assess re-identification risks from operational metadata.
+//
+// # HIPAA note
+//
+// Authentication and authorisation failures are emitted with the audit code
+// "llm_auth_error" to support HIPAA §164.312(b) audit control requirements.
 type AuditedLLM struct {
 	inner LLM
 }
@@ -18,10 +42,29 @@ func NewAudited(inner LLM) LLM {
 
 func (a *AuditedLLM) Name() string { return a.inner.Name() }
 
+// auditEvent classifies a call outcome for HIPAA §164.312(b) audit trail purposes.
+func auditEvent(err error) string {
+	if err == nil {
+		return "llm_complete_ok"
+	}
+	// Classify authentication/authorisation failures separately.
+	var httpErr interface{ StatusCode() int }
+	if errors.As(err, &httpErr) {
+		code := httpErr.StatusCode()
+		if code == http.StatusUnauthorized || code == http.StatusForbidden {
+			return "llm_auth_error"
+		}
+	}
+	return "llm_complete_error"
+}
+
 func (a *AuditedLLM) Complete(ctx context.Context, req CompletionRequest) (CompletionResponse, error) {
 	start := time.Now()
 	resp, err := a.inner.Complete(ctx, req)
+	// Note: req.Messages and resp.Content are intentionally omitted to prevent
+	// logging PHI/PII/PAN. Only operational metadata is recorded.
 	slog.Info("llm.Complete",
+		"audit_event", auditEvent(err),
 		"provider", a.inner.Name(),
 		"model", resp.Model,
 		"input_tokens", resp.InputTokens,
@@ -33,7 +76,38 @@ func (a *AuditedLLM) Complete(ctx context.Context, req CompletionRequest) (Compl
 	return resp, err
 }
 
+// StreamComplete wraps the inner stream and emits a completion audit entry when the
+// stream closes, including latency. Content chunks are intentionally not logged to
+// prevent PHI/PII/PAN exposure.
 func (a *AuditedLLM) StreamComplete(ctx context.Context, req CompletionRequest) (<-chan StreamChunk, error) {
-	slog.Info("llm.StreamComplete", "provider", a.inner.Name())
-	return a.inner.StreamComplete(ctx, req)
+	inner, err := a.inner.StreamComplete(ctx, req)
+	if err != nil {
+		slog.Info("llm.StreamComplete",
+			"audit_event", auditEvent(err),
+			"provider", a.inner.Name(),
+			"error", err,
+		)
+		return nil, err
+	}
+
+	start := time.Now()
+	out := make(chan StreamChunk)
+	go func() {
+		defer close(out)
+		var lastErr error
+		for chunk := range inner {
+			out <- chunk
+			if chunk.Error != nil {
+				lastErr = chunk.Error
+			}
+		}
+		// Emit audit entry at stream closure. Content is intentionally omitted.
+		slog.Info("llm.StreamComplete",
+			"audit_event", auditEvent(lastErr),
+			"provider", a.inner.Name(),
+			"latency_ms", time.Since(start).Milliseconds(),
+			"error", lastErr,
+		)
+	}()
+	return out, nil
 }

--- a/internal/llm/claude.go
+++ b/internal/llm/claude.go
@@ -14,12 +14,19 @@ type ClaudeBackend struct {
 	model  string
 }
 
-func NewClaude(apiKey, model string) *ClaudeBackend {
+// newClaudeBackend constructs the raw backend without auditing.
+// Use NewClaude to get an audited instance.
+func newClaudeBackend(apiKey, model string) *ClaudeBackend {
 	client := anthropic.NewClient(option.WithAPIKey(apiKey))
 	return &ClaudeBackend{
 		client: client,
 		model:  model,
 	}
+}
+
+// NewClaude returns an audited LLM backed by Anthropic Claude.
+func NewClaude(apiKey, model string) LLM {
+	return NewAudited(newClaudeBackend(apiKey, model))
 }
 
 func (c *ClaudeBackend) Name() string {

--- a/internal/llm/llm.go
+++ b/internal/llm/llm.go
@@ -35,6 +35,12 @@ type StreamChunk struct {
 	Content string
 	Done    bool
 	Error   error
+	// Usage is populated on the final chunk (Done==true) by backends that surface
+	// token counts in the streaming API. Zero values indicate the backend does not
+	// report per-stream usage; cost tracking will be unavailable for that call.
+	InputTokens  int
+	OutputTokens int
+	Cost         float64
 }
 
 type LLM interface {

--- a/internal/llm/openai.go
+++ b/internal/llm/openai.go
@@ -14,12 +14,19 @@ type OpenAIBackend struct {
 	model  string
 }
 
-func NewOpenAI(apiKey, model string) *OpenAIBackend {
+// newOpenAIBackend constructs the raw backend without auditing.
+// Use NewOpenAI to get an audited instance.
+func newOpenAIBackend(apiKey, model string) *OpenAIBackend {
 	client := openai.NewClient(option.WithAPIKey(apiKey))
 	return &OpenAIBackend{
 		client: client,
 		model:  model,
 	}
+}
+
+// NewOpenAI returns an audited LLM backed by OpenAI.
+func NewOpenAI(apiKey, model string) LLM {
+	return NewAudited(newOpenAIBackend(apiKey, model))
 }
 
 func (o *OpenAIBackend) Name() string {


### PR DESCRIPTION
## Implementation for #-1169202776

**Issue:** Fix 2 agent_sec_001 security findings

### Approved Plan
Now I have enough context to write the plan.

---

### Approach

Introduce an `AuditedLLM` decorator in the `llm` package that wraps any `LLM` implementation and emits structured `slog` log lines for every `Complete`/`StreamComplete` call (provider, model, token counts, cost, latency, error). Then:
- Fix finding #2 by having `NewOpenAI` delegate client construction to an unexported helper and return a wrapped audited instance.
- Fix finding #1 by replacing the direct backend assignments in `app.go:buildJobHandler` with calls through the auditing factory.

No new config systems, no changes outside these files, no unrelated refactoring.

---

### Files to Modify

| File | Action |
|---|---|
| `internal/llm/audit.go` | **Create** — `AuditedLLM` struct and `NewAudited(inner LLM) LLM` factory |
| `internal/llm/openai.go` | **Modify** — make raw `openai.NewClient` call unexported; have `NewOpenAI` return `NewAudited(...)` |
| `internal/app/app.go` | **Modify** — wrap both `NewOpenAI` and `NewClaude` returns with `llm.NewAudited(...)` (explicit at call-site) |

---

### Implementation Steps

**Step 1 — Create `internal/llm/audit.go`**

```go
package llm

import (
    "context"
    "log/slog"
    "time"
)

// AuditedLLM wraps any LLM and emits a structured audit log entry on every call.
type AuditedLLM struct {
    inner LLM
}

// NewAudited returns an LLM that wraps inner with audit logging.
func NewAudited(inner LLM) LLM {
    return &AuditedLLM{inner: inner}
}

func (a *AuditedLLM) Name() string { return a.inner.Name() }

func (a *AuditedLLM) Complete(ctx context.Context, req CompletionRequest) (CompletionResponse, error) {
    start := time.Now()
    resp, err := a.inner.Complete(ctx, req)
    slog.Info("llm.Complete",
        "provider", a.inner.Name(),
        "model", resp.Model,
        "input_tokens", resp.InputTokens,
        "output_tokens", resp.OutputTokens,
        "cost_usd", resp.Cost,
        "latency_ms", time.Since(start).Milliseconds(),
        "error", 

### Files Changed
- `internal/llm/audit.go`
- `internal/llm/claude.go`
- `internal/llm/openai.go`

---
*Created by NeuralWarden Autopilot (event-driven recovery)*