### PR TITLE
feat: implement #-901492907 — Fix 1 osv_ghsa_hp87_p4gw_j4gq security finding

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -149,7 +149,6 @@ gopkg.in/inf.v0 v0.9.1 h1:73M5CoZyi3ZLMOyDlQh031Cx6N9NDJ2Vvfl76EDAgDc=
 gopkg.in/inf.v0 v0.9.1/go.mod h1:cWUDdTG/fYaXco+Dcufb5Vnc6Gp2YChqWtbxRZE0mXw=
 gopkg.in/yaml.v2 v2.2.8 h1:obN1ZagJSUGI0Ek/LBmuj4SNLPfIny3KsKFopxRdj10=
 gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
-gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 k8s.io/api v0.35.2 h1:tW7mWc2RpxW7HS4CoRXhtYHSzme1PN1UjGHJ1bdrtdw=


### PR DESCRIPTION
## Implementation for #-901492907

**Issue:** Fix 1 osv_ghsa_hp87_p4gw_j4gq security finding

### Approved Plan
---

### Approach

The scanner flagged `go.sum` line 152:
```
gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
```

This is **only a `go.mod` checksum** (note the `/go.mod` suffix) — not a compiled source hash. The vulnerable pre-release code is never compiled; the actual used version is `v3.0.1` (the fixed release, lines 153–154 of `go.sum`). The old `/go.mod` hash is present because some transitive dependency's own `go.mod` declared `gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c` as a minimum version requirement, and Go records those for module graph verification.

The fix is to run `go mod tidy`, which prunes stale `go.sum` entries that are no longer reachable in the build graph. If the entry survives tidy (because a still-used dependency's `go.mod` pins the old version), the transitive dependency must be upgraded.

---

### Files to Modify

| File | Change |
|---|---|
| `go.sum` | Remove the vulnerable version's `/go.mod` hash entry (done automatically by `go mod tidy`) |
| `go.mod` | Possibly add a `require` bump or `go get` for a transitive dep if tidy alone isn't sufficient |

---

### Implementation Steps

1. **Run `go mod tidy`** from the repository root:
   ```
   go mod tidy
   ```
   This removes all `go.sum` entries that are no longer reachable in the module graph, including the stale `gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod` line.

2. **Verify the entry is gone** from `go.sum`:
   ```
   grep "9f266ea9e77c" go.sum
   ```
   Expected: no output.

3. **If the entry persists** (some transitive dep still pins the old version in its own `go.mod`), identify the culprit:
   ```
   go mod graph | grep "gopkg.in/yaml.v3@v3.0.0-20200313102051"
   ```
   Then upgrade that dependency, e.g.:
   ```
   go get <culprit-module>@latest
   go mod tidy
   ```

4. **If no upgrade is available**, add an explicit minimum version override in `go.mod`:
   ```
   require gopkg.in/yaml.v3 v3.0.1


### Files Changed
- `go.sum`

---
*Created by NeuralWarden Autopilot (event-driven recovery)*