### PR TITLE
feat: implement #-1953661596 — Fix 1 osv_ghsa_hp87_p4gw_j4gq security finding

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -149,7 +149,6 @@ gopkg.in/inf.v0 v0.9.1 h1:73M5CoZyi3ZLMOyDlQh031Cx6N9NDJ2Vvfl76EDAgDc=
 gopkg.in/inf.v0 v0.9.1/go.mod h1:cWUDdTG/fYaXco+Dcufb5Vnc6Gp2YChqWtbxRZE0mXw=
 gopkg.in/yaml.v2 v2.2.8 h1:obN1ZagJSUGI0Ek/LBmuj4SNLPfIny3KsKFopxRdj10=
 gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
-gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 k8s.io/api v0.35.2 h1:tW7mWc2RpxW7HS4CoRXhtYHSzme1PN1UjGHJ1bdrtdw=


### PR DESCRIPTION
## Implementation for #-1953661596

**Issue:** Fix 1 osv_ghsa_hp87_p4gw_j4gq security finding

### Approved Plan
Now I have a complete picture. Let me summarize the findings before writing the plan.

**Key observations:**
- `go.mod` already uses `gopkg.in/yaml.v3 v3.0.1` (patched) as a direct dependency
- `go.sum` contains `v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:...` — note the `/go.mod` suffix, meaning only the go.mod checksum of the vulnerable pre-release was recorded, not the source code
- The vulnerable source code is never compiled — Go's MVS uses v3.0.1
- The scanner is flagging the stale go.sum reference, not actual code usage

---

### Approach

GHSA-hp87-p4gw-j4gq (DoS via crafted YAML) affects `gopkg.in/yaml.v3` versions before `v3.0.0`. The project already directly requires `v3.0.1` (patched). The scanner flags a stale `/go.mod`-only entry for the pre-release in `go.sum` — this entry was recorded when resolving a transitive dependency's module graph, but no vulnerable source code is compiled.

The fix is to run `go mod tidy` to remove the stale go.sum entry, silencing the scanner without any functional change.

---

### Files to Modify

| File | Action |
|------|--------|
| `go.sum` | Remove stale `v3.0.0-20200313102051-9f266ea9e77c/go.mod` entry via `go mod tidy` |

`go.mod` requires **no changes** — `v3.0.1` is already the declared version.

---

### Implementation Steps

1. **Run `go mod tidy`** in the repository root:
   ```
   go mod tidy
   ```
   This re-computes the minimal set of go.sum entries needed. If the pre-release `/go.mod` entry is no longer required for any transitive dependency's module graph resolution, it will be removed automatically.

2. **Verify go.sum** no longer contains the vulnerable version reference:
   ```
   grep "yaml.v3 v3.0.0" go.sum
   # Expected: no output
   ```

3. **If the entry persists** (because a transitive dependency's own go.mod still references that pre-release), identify the culprit with `go mod graph | grep yaml.v3` and upgrade the offending dependency to a version whose go.mod references `v3.0.1` or later. Give

### Files Changed
- `go.sum`

---
*Created by NeuralWarden Autopilot (event-driven recovery)*