### PR TITLE
feat: implement #-1442059316 — Fix 1 osv_go_2022_0603 security finding

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -149,7 +149,6 @@ gopkg.in/inf.v0 v0.9.1 h1:73M5CoZyi3ZLMOyDlQh031Cx6N9NDJ2Vvfl76EDAgDc=
 gopkg.in/inf.v0 v0.9.1/go.mod h1:cWUDdTG/fYaXco+Dcufb5Vnc6Gp2YChqWtbxRZE0mXw=
 gopkg.in/yaml.v2 v2.2.8 h1:obN1ZagJSUGI0Ek/LBmuj4SNLPfIny3KsKFopxRdj10=
 gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
-gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 k8s.io/api v0.35.2 h1:tW7mWc2RpxW7HS4CoRXhtYHSzme1PN1UjGHJ1bdrtdw=


### PR DESCRIPTION
## Implementation for #-1442059316

**Issue:** Fix 1 osv_go_2022_0603 security finding

### Approved Plan
Now I have a clear picture of the issue. Let me summarize my findings and produce the implementation plan.

**Key observations:**
- `go.mod` already declares `gopkg.in/yaml.v3 v3.0.1` as a direct dependency (safe, patched version)
- `go.sum` line 152 contains a `/go.mod`-only entry for the vulnerable pre-release version `v3.0.0-20200313102051-9f266ea9e77c` — recorded because a transitive dependency's `go.mod` once referenced this old version
- The vulnerable version has **no** `h1:` content hash in go.sum (only a `/go.mod` hash), meaning the vulnerable code was never actually downloaded or compiled
- The actual YAML parsing in `internal/config/repoconfig.go` uses `v3.0.1`

---

### Approach

OSV-GO-2022-0603 flags the stale `go.sum` entry for the pre-release `gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c`. The current `go.mod` already pins `v3.0.1` (patched), so the fix is to run `go mod tidy` to prune the stale go.sum entries, which removes the scanner trigger.

### Files to Modify

- `go.sum` — remove stale `/go.mod` entry for `gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c` (via `go mod tidy`)

No changes to `go.mod` are needed since it already requires `v3.0.1`.

### Implementation Steps

1. **Run `go mod tidy`** from the repository root:
   ```
   go mod tidy
   ```
   This command re-computes the full module graph and removes any go.sum entries that are no longer needed. The stale `/go.mod` entry for the pre-release version should be pruned because no current dependency in the graph requires it.

2. **Verify the entry is gone** from `go.sum`:
   ```
   grep "gopkg.in/yaml.v3 v3.0.0-20200313102051" go.sum
   ```
   Expected: no output.

3. **Verify the safe version is still present** in `go.sum`:
   ```
   grep "gopkg.in/yaml.v3" go.sum
   ```
   Expected: only the `v3.0.1` entries remain.

### Testing

1. Confirm `go mod tidy` exits cleanly (no errors).
2. Run `make build` to ensure the project compiles successfully.
3. Run `make test` to ensure no 

### Files Changed
- `go.sum`

---
*Created by NeuralWarden Autopilot (event-driven recovery)*