### PR TITLE
feat: implement #-31866457 — Fix 1 osv_ghsa_hp87_p4gw_j4gq security finding

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -149,7 +149,6 @@ gopkg.in/inf.v0 v0.9.1 h1:73M5CoZyi3ZLMOyDlQh031Cx6N9NDJ2Vvfl76EDAgDc=
 gopkg.in/inf.v0 v0.9.1/go.mod h1:cWUDdTG/fYaXco+Dcufb5Vnc6Gp2YChqWtbxRZE0mXw=
 gopkg.in/yaml.v2 v2.2.8 h1:obN1ZagJSUGI0Ek/LBmuj4SNLPfIny3KsKFopxRdj10=
 gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
-gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 k8s.io/api v0.35.2 h1:tW7mWc2RpxW7HS4CoRXhtYHSzme1PN1UjGHJ1bdrtdw=


### PR DESCRIPTION
## Implementation for #-31866457

**Issue:** Fix 1 osv_ghsa_hp87_p4gw_j4gq security finding

### Approved Plan
### Approach

The security scanner (GHSA-hp87-p4gw-j4gq) flags `gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c` found in `go.sum`. This is a pre-release pseudo-version of yaml.v3 that predates the `v3.0.0` release. The library is actively used in `internal/config/repoconfig.go` for YAML unmarshaling.

**Key observations:**
- `go.mod` already pins `gopkg.in/yaml.v3 v3.0.1` (patched version) as a direct dependency.
- `go.sum` line 152 contains a `/go.mod`-only hash for the old pseudo-version — this means some transitive dependency's `go.mod` references that older version, so Go retained its module graph hash for verification.
- The actual compiled binary uses `v3.0.1` (via MVS), so this is effectively a false positive in terms of runtime exposure — but the scanner flags the `go.sum` entry itself.
- The fix is to clean up the stale `go.sum` reference, either via `go mod tidy` or by upgrading the transitive dep that pulls in the old version.

---

### Files to Modify

| File | Change |
|------|--------|
| `go.sum` | Remove stale `/go.mod` hash entry for `gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c` |
| `go.mod` | No version change needed (already on `v3.0.1`); may gain a `// indirect` comment cleanup from tidy |

---

### Implementation Steps

1. **Run `go mod tidy`** to prune any stale/unused entries from `go.sum`:
   ```
   go mod tidy
   ```
   This regenerates `go.sum` based on the current dependency graph and removes orphaned hashes that are no longer reachable.

2. **Verify whether the stale entry was removed** by checking `go.sum`:
   ```
   grep 'yaml.v3 v3.0.0' go.sum
   ```
   - If the line is gone: done. Proceed to step 5.
   - If the line persists: some transitive dependency's `go.mod` still references the old pseudo-version and Go MVS requires the hash for graph verification. Proceed to step 3.

3. **Identify the transitive dependency** pulling in the old version:
   ```
   go mod graph | grep 'yaml.v3@v3.0.0'
   ```
   This shows which module 

### Files Changed
- `go.sum`

---
*Created by NeuralWarden Autopilot (event-driven recovery)*