### PR TITLE
feat: implement #-751139312 — Fix 2 agent_sec_001 security findings

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -61,7 +61,11 @@ func New(cfg config.Config) (*App, error) {
 		a.ghApp = ghApp
 	}
 
-	handler := a.buildJobHandler()
+	handler, err := a.buildJobHandler()
+	if err != nil {
+		s.Close()
+		return nil, fmt.Errorf("build job handler: %w", err)
+	}
 	a.pool = worker.NewPool(cfg.Workers, s, handler)
 
 	mux := http.NewServeMux()
@@ -170,14 +174,17 @@ func (a *App) handleEvent(eventType string, payload []byte) {
 
 // buildJobHandler creates the LLM backend and executor, then returns a handler
 // that clones the repo, builds pipeline state, and runs the pipeline engine.
-func (a *App) buildJobHandler() worker.JobHandler {
+func (a *App) buildJobHandler() (worker.JobHandler, error) {
 	// Create LLM backend based on config.
-	var backend llm.LLM
-	switch a.cfg.LLM.DefaultProvider {
-	case "openai":
-		backend = llm.NewOpenAI(a.cfg.LLM.OpenAI.APIKey, a.cfg.LLM.OpenAI.Model)
-	default:
-		backend = llm.NewClaude(a.cfg.LLM.Claude.APIKey, a.cfg.LLM.Claude.Model)
+	apiKey := a.cfg.LLM.Claude.APIKey
+	model := a.cfg.LLM.Claude.Model
+	if a.cfg.LLM.DefaultProvider == "openai" {
+		apiKey = a.cfg.LLM.OpenAI.APIKey
+		model = a.cfg.LLM.OpenAI.Model
+	}
+	backend, err := llm.New(a.cfg.LLM.DefaultProvider, apiKey, model)
+	if err != nil {
+		return nil, fmt.Errorf("create llm backend: %w", err)
 	}
 
 	// Create executor based on config.
@@ -305,5 +312,5 @@ func (a *App) buildJobHandler() worker.JobHandler {
 
 		slog.Info("job completed", "job_id", job.ID, "cost", state.Cost)
 		return nil
-	}
+	}, nil
 }

--- a/internal/llm/audit.go
+++ b/internal/llm/audit.go
@@ -2,9 +2,42 @@ package llm
 
 import (
 	"context"
+	"crypto/sha256"
+	"fmt"
 	"log/slog"
 	"time"
 )
+
+// auditActorKey is the context key used to propagate an actor/user identifier
+// into audit log entries (SOX segregation-of-duties).
+type auditActorKey struct{}
+
+// WithActor returns a context that carries the given actor identifier.
+// Callers (e.g. job handlers) should inject this before invoking LLM methods.
+func WithActor(ctx context.Context, actor string) context.Context {
+	return context.WithValue(ctx, auditActorKey{}, actor)
+}
+
+// actorFromCtx extracts the actor identifier from the context, or returns
+// "unknown" when none has been set.
+func actorFromCtx(ctx context.Context) string {
+	if v, ok := ctx.Value(auditActorKey{}).(string); ok && v != "" {
+		return v
+	}
+	return "unknown"
+}
+
+// promptHash returns a stable SHA-256 hex digest of the request's system
+// prompt and messages. This satisfies GDPR Article 30 processing records
+// (data minimization) without logging raw prompt content.
+func promptHash(req CompletionRequest) string {
+	h := sha256.New()
+	fmt.Fprint(h, req.System)
+	for _, m := range req.Messages {
+		fmt.Fprintf(h, "%s:%s", m.Role, m.Content)
+	}
+	return fmt.Sprintf("%x", h.Sum(nil))[:16]
+}
 
 // AuditedLLM wraps any LLM and emits structured audit log entries for every call.
 type AuditedLLM struct {
@@ -29,6 +62,8 @@ func (a *AuditedLLM) Complete(ctx context.Context, req CompletionRequest) (Compl
 		"output_tokens", resp.OutputTokens,
 		"cost_usd", resp.Cost,
 		"latency_ms", time.Since(start).Milliseconds(),
+		"actor", actorFromCtx(ctx),
+		"prompt_hash", promptHash(req),
 	}
 	if err != nil {
 		slog.Error("llm audit: Complete failed", append(attrs, "error", err)...)
@@ -38,7 +73,59 @@ func (a *AuditedLLM) Complete(ctx context.Context, req CompletionRequest) (Compl
 	return resp, err
 }
 
+// StreamComplete initiates a streaming completion and wraps the returned channel
+// so that completion events and errors are captured in the audit log.
 func (a *AuditedLLM) StreamComplete(ctx context.Context, req CompletionRequest) (<-chan StreamChunk, error) {
-	slog.Info("llm audit: StreamComplete requested", "provider", a.inner.Name())
-	return a.inner.StreamComplete(ctx, req)
+	start := time.Now()
+	actor := actorFromCtx(ctx)
+	pHash := promptHash(req)
+
+	slog.Info("llm audit: StreamComplete started",
+		"provider", a.inner.Name(),
+		"actor", actor,
+		"prompt_hash", pHash,
+	)
+
+	inner, err := a.inner.StreamComplete(ctx, req)
+	if err != nil {
+		slog.Error("llm audit: StreamComplete failed",
+			"provider", a.inner.Name(),
+			"actor", actor,
+			"prompt_hash", pHash,
+			"latency_ms", time.Since(start).Milliseconds(),
+			"error", err,
+		)
+		return nil, err
+	}
+
+	// Wrap the channel to observe completion and per-chunk errors.
+	out := make(chan StreamChunk)
+	go func() {
+		defer close(out)
+		var chunkCount int
+		var lastErr error
+		for chunk := range inner {
+			if chunk.Error != nil {
+				lastErr = chunk.Error
+			}
+			if !chunk.Done {
+				chunkCount++
+			}
+			out <- chunk
+		}
+		attrs := []any{
+			"provider", a.inner.Name(),
+			"actor", actor,
+			"prompt_hash", pHash,
+			"chunks", chunkCount,
+			"latency_ms", time.Since(start).Milliseconds(),
+		}
+		if lastErr != nil {
+			slog.Error("llm audit: StreamComplete completed with error", append(attrs, "error", lastErr)...)
+		} else {
+			slog.Info("llm audit: StreamComplete completed", attrs...)
+		}
+	}()
+
+	return out, nil
 }

--- a/internal/llm/audit.go
+++ b/internal/llm/audit.go
@@ -82,6 +82,7 @@ func (a *AuditedLLM) StreamComplete(ctx context.Context, req CompletionRequest) 
 
 	slog.Info("llm audit: StreamComplete started",
 		"provider", a.inner.Name(),
+		"model", req.Model,
 		"actor", actor,
 		"prompt_hash", pHash,
 	)
@@ -90,6 +91,7 @@ func (a *AuditedLLM) StreamComplete(ctx context.Context, req CompletionRequest) 
 	if err != nil {
 		slog.Error("llm audit: StreamComplete failed",
 			"provider", a.inner.Name(),
+			"model", req.Model,
 			"actor", actor,
 			"prompt_hash", pHash,
 			"latency_ms", time.Since(start).Milliseconds(),
@@ -115,6 +117,7 @@ func (a *AuditedLLM) StreamComplete(ctx context.Context, req CompletionRequest) 
 		}
 		attrs := []any{
 			"provider", a.inner.Name(),
+			"model", req.Model,
 			"actor", actor,
 			"prompt_hash", pHash,
 			"chunks", chunkCount,

--- a/internal/llm/audit.go
+++ b/internal/llm/audit.go
@@ -1,0 +1,44 @@
+package llm
+
+import (
+	"context"
+	"log/slog"
+	"time"
+)
+
+// AuditedLLM wraps any LLM and emits structured audit log entries for every call.
+type AuditedLLM struct {
+	inner LLM
+}
+
+// NewAudited wraps inner with audit logging. All callers should obtain LLM
+// instances via the llm.New factory rather than constructing backends directly.
+func NewAudited(inner LLM) LLM {
+	return &AuditedLLM{inner: inner}
+}
+
+func (a *AuditedLLM) Name() string { return a.inner.Name() }
+
+func (a *AuditedLLM) Complete(ctx context.Context, req CompletionRequest) (CompletionResponse, error) {
+	start := time.Now()
+	resp, err := a.inner.Complete(ctx, req)
+	attrs := []any{
+		"provider", a.inner.Name(),
+		"model", resp.Model,
+		"input_tokens", resp.InputTokens,
+		"output_tokens", resp.OutputTokens,
+		"cost_usd", resp.Cost,
+		"latency_ms", time.Since(start).Milliseconds(),
+	}
+	if err != nil {
+		slog.Error("llm audit: Complete failed", append(attrs, "error", err)...)
+	} else {
+		slog.Info("llm audit: Complete", attrs...)
+	}
+	return resp, err
+}
+
+func (a *AuditedLLM) StreamComplete(ctx context.Context, req CompletionRequest) (<-chan StreamChunk, error) {
+	slog.Info("llm audit: StreamComplete requested", "provider", a.inner.Name())
+	return a.inner.StreamComplete(ctx, req)
+}

--- a/internal/llm/audit_test.go
+++ b/internal/llm/audit_test.go
@@ -1,0 +1,278 @@
+package llm
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// captureHandler is a simple slog.Handler that records log records for assertions.
+type captureHandler struct {
+	mu      sync.Mutex
+	records []slog.Record
+}
+
+func (h *captureHandler) Enabled(_ context.Context, _ slog.Level) bool { return true }
+
+func (h *captureHandler) Handle(_ context.Context, r slog.Record) error {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.records = append(h.records, r)
+	return nil
+}
+
+func (h *captureHandler) WithAttrs(attrs []slog.Attr) slog.Handler { return h }
+func (h *captureHandler) WithGroup(name string) slog.Handler       { return h }
+
+func (h *captureHandler) attrMap(idx int) map[string]any {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	m := make(map[string]any)
+	h.records[idx].Attrs(func(a slog.Attr) bool {
+		m[a.Key] = a.Value.Any()
+		return true
+	})
+	return m
+}
+
+func (h *captureHandler) len() int {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	return len(h.records)
+}
+
+func (h *captureHandler) level(idx int) slog.Level {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	return h.records[idx].Level
+}
+
+func (h *captureHandler) message(idx int) string {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	return h.records[idx].Message
+}
+
+// mockLLM is a test double for the LLM interface.
+type mockLLM struct {
+	name     string
+	completeFunc func(ctx context.Context, req CompletionRequest) (CompletionResponse, error)
+	streamFunc   func(ctx context.Context, req CompletionRequest) (<-chan StreamChunk, error)
+}
+
+func (m *mockLLM) Name() string { return m.name }
+
+func (m *mockLLM) Complete(ctx context.Context, req CompletionRequest) (CompletionResponse, error) {
+	if m.completeFunc != nil {
+		return m.completeFunc(ctx, req)
+	}
+	return CompletionResponse{
+		Content:      "test response",
+		Model:        "test-model",
+		InputTokens:  10,
+		OutputTokens: 20,
+		Cost:         0.001,
+	}, nil
+}
+
+func (m *mockLLM) StreamComplete(ctx context.Context, req CompletionRequest) (<-chan StreamChunk, error) {
+	if m.streamFunc != nil {
+		return m.streamFunc(ctx, req)
+	}
+	ch := make(chan StreamChunk, 2)
+	ch <- StreamChunk{Content: "hello"}
+	ch <- StreamChunk{Done: true}
+	close(ch)
+	return ch, nil
+}
+
+func TestAuditedLLM_Complete_LogsFields(t *testing.T) {
+	h := &captureHandler{}
+	old := slog.Default()
+	slog.SetDefault(slog.New(h))
+	defer slog.SetDefault(old)
+
+	mock := &mockLLM{name: "mock-provider"}
+	audited := NewAudited(mock)
+
+	req := CompletionRequest{
+		System:   "you are helpful",
+		Messages: []Message{{Role: RoleUser, Content: "hello"}},
+	}
+	ctx := WithActor(context.Background(), "user-42")
+
+	resp, err := audited.Complete(ctx, req)
+	require.NoError(t, err)
+	assert.Equal(t, "test response", resp.Content)
+
+	require.Equal(t, 1, h.len())
+	assert.Equal(t, slog.LevelInfo, h.level(0))
+	assert.Equal(t, "llm audit: Complete", h.message(0))
+
+	attrs := h.attrMap(0)
+	assert.Equal(t, "mock-provider", attrs["provider"])
+	assert.Equal(t, "test-model", attrs["model"])
+	assert.NotNil(t, attrs["input_tokens"])
+	assert.NotNil(t, attrs["output_tokens"])
+	assert.NotNil(t, attrs["cost_usd"])
+	assert.NotNil(t, attrs["latency_ms"])
+	assert.Equal(t, "user-42", attrs["actor"])
+	assert.NotEmpty(t, attrs["prompt_hash"])
+}
+
+func TestAuditedLLM_Complete_LogsError(t *testing.T) {
+	h := &captureHandler{}
+	old := slog.Default()
+	slog.SetDefault(slog.New(h))
+	defer slog.SetDefault(old)
+
+	wantErr := errors.New("backend failure")
+	mock := &mockLLM{
+		name: "mock-provider",
+		completeFunc: func(_ context.Context, _ CompletionRequest) (CompletionResponse, error) {
+			return CompletionResponse{}, wantErr
+		},
+	}
+	audited := NewAudited(mock)
+
+	_, err := audited.Complete(context.Background(), CompletionRequest{})
+	assert.ErrorIs(t, err, wantErr)
+
+	require.Equal(t, 1, h.len())
+	assert.Equal(t, slog.LevelError, h.level(0))
+	assert.Equal(t, "llm audit: Complete failed", h.message(0))
+}
+
+func TestAuditedLLM_Complete_ActorUnknownWhenNotSet(t *testing.T) {
+	h := &captureHandler{}
+	old := slog.Default()
+	slog.SetDefault(slog.New(h))
+	defer slog.SetDefault(old)
+
+	audited := NewAudited(&mockLLM{name: "p"})
+	_, err := audited.Complete(context.Background(), CompletionRequest{})
+	require.NoError(t, err)
+
+	attrs := h.attrMap(0)
+	assert.Equal(t, "unknown", attrs["actor"])
+}
+
+func TestAuditedLLM_Complete_PromptHashIsStable(t *testing.T) {
+	req := CompletionRequest{
+		System:   "sys",
+		Messages: []Message{{Role: RoleUser, Content: "msg"}},
+	}
+	h1 := promptHash(req)
+	h2 := promptHash(req)
+	assert.Equal(t, h1, h2)
+	assert.Len(t, h1, 16)
+}
+
+func TestAuditedLLM_StreamComplete_LogsStartAndCompletion(t *testing.T) {
+	h := &captureHandler{}
+	old := slog.Default()
+	slog.SetDefault(slog.New(h))
+	defer slog.SetDefault(old)
+
+	mock := &mockLLM{name: "mock-provider"}
+	audited := NewAudited(mock)
+
+	ctx := WithActor(context.Background(), "stream-user")
+	ch, err := audited.StreamComplete(ctx, CompletionRequest{System: "s"})
+	require.NoError(t, err)
+
+	// drain channel
+	for range ch {
+	}
+
+	// expect start + completion log
+	require.Equal(t, 2, h.len())
+	assert.Equal(t, "llm audit: StreamComplete started", h.message(0))
+	assert.Equal(t, slog.LevelInfo, h.level(0))
+
+	startAttrs := h.attrMap(0)
+	assert.Equal(t, "mock-provider", startAttrs["provider"])
+	assert.Equal(t, "stream-user", startAttrs["actor"])
+	assert.NotEmpty(t, startAttrs["prompt_hash"])
+
+	assert.Equal(t, "llm audit: StreamComplete completed", h.message(1))
+	assert.Equal(t, slog.LevelInfo, h.level(1))
+
+	doneAttrs := h.attrMap(1)
+	assert.Equal(t, "mock-provider", doneAttrs["provider"])
+	assert.NotNil(t, doneAttrs["chunks"])
+	assert.NotNil(t, doneAttrs["latency_ms"])
+}
+
+func TestAuditedLLM_StreamComplete_LogsInitError(t *testing.T) {
+	h := &captureHandler{}
+	old := slog.Default()
+	slog.SetDefault(slog.New(h))
+	defer slog.SetDefault(old)
+
+	wantErr := errors.New("stream init failure")
+	mock := &mockLLM{
+		name: "mock-provider",
+		streamFunc: func(_ context.Context, _ CompletionRequest) (<-chan StreamChunk, error) {
+			return nil, wantErr
+		},
+	}
+	audited := NewAudited(mock)
+
+	_, err := audited.StreamComplete(context.Background(), CompletionRequest{})
+	assert.ErrorIs(t, err, wantErr)
+
+	require.Equal(t, 2, h.len())
+	assert.Equal(t, "llm audit: StreamComplete started", h.message(0))
+	assert.Equal(t, slog.LevelError, h.level(1))
+	assert.Equal(t, "llm audit: StreamComplete failed", h.message(1))
+}
+
+func TestAuditedLLM_StreamComplete_LogsChunkError(t *testing.T) {
+	h := &captureHandler{}
+	old := slog.Default()
+	slog.SetDefault(slog.New(h))
+	defer slog.SetDefault(old)
+
+	chunkErr := errors.New("chunk error")
+	mock := &mockLLM{
+		name: "mock-provider",
+		streamFunc: func(_ context.Context, _ CompletionRequest) (<-chan StreamChunk, error) {
+			ch := make(chan StreamChunk, 2)
+			ch <- StreamChunk{Content: "partial"}
+			ch <- StreamChunk{Error: chunkErr, Done: true}
+			close(ch)
+			return ch, nil
+		},
+	}
+	audited := NewAudited(mock)
+
+	ch, err := audited.StreamComplete(context.Background(), CompletionRequest{})
+	require.NoError(t, err)
+	for range ch {
+	}
+
+	require.Equal(t, 2, h.len())
+	assert.Equal(t, slog.LevelError, h.level(1))
+	assert.Equal(t, "llm audit: StreamComplete completed with error", h.message(1))
+}
+
+func TestAuditedLLM_Name_DelegatesInner(t *testing.T) {
+	mock := &mockLLM{name: "my-backend"}
+	audited := NewAudited(mock)
+	assert.Equal(t, "my-backend", audited.Name())
+}
+
+func TestWithActor(t *testing.T) {
+	ctx := WithActor(context.Background(), "alice")
+	assert.Equal(t, "alice", actorFromCtx(ctx))
+}
+
+func TestActorFromCtx_NoActor(t *testing.T) {
+	assert.Equal(t, "unknown", actorFromCtx(context.Background()))
+}

--- a/internal/llm/audit_test.go
+++ b/internal/llm/audit_test.go
@@ -183,7 +183,7 @@ func TestAuditedLLM_StreamComplete_LogsStartAndCompletion(t *testing.T) {
 	audited := NewAudited(mock)
 
 	ctx := WithActor(context.Background(), "stream-user")
-	ch, err := audited.StreamComplete(ctx, CompletionRequest{System: "s"})
+	ch, err := audited.StreamComplete(ctx, CompletionRequest{System: "s", Model: "test-stream-model"})
 	require.NoError(t, err)
 
 	// drain channel
@@ -197,6 +197,7 @@ func TestAuditedLLM_StreamComplete_LogsStartAndCompletion(t *testing.T) {
 
 	startAttrs := h.attrMap(0)
 	assert.Equal(t, "mock-provider", startAttrs["provider"])
+	assert.Equal(t, "test-stream-model", startAttrs["model"])
 	assert.Equal(t, "stream-user", startAttrs["actor"])
 	assert.NotEmpty(t, startAttrs["prompt_hash"])
 
@@ -205,6 +206,7 @@ func TestAuditedLLM_StreamComplete_LogsStartAndCompletion(t *testing.T) {
 
 	doneAttrs := h.attrMap(1)
 	assert.Equal(t, "mock-provider", doneAttrs["provider"])
+	assert.Equal(t, "test-stream-model", doneAttrs["model"])
 	assert.NotNil(t, doneAttrs["chunks"])
 	assert.NotNil(t, doneAttrs["latency_ms"])
 }

--- a/internal/llm/factory.go
+++ b/internal/llm/factory.go
@@ -1,0 +1,19 @@
+package llm
+
+import "fmt"
+
+// New creates an audited LLM backend for the given provider.
+// It is the only sanctioned way to obtain an LLM instance; direct construction
+// of OpenAIBackend or ClaudeBackend bypasses the audit layer.
+func New(provider, apiKey, model string) (LLM, error) {
+	var inner LLM
+	switch provider {
+	case "openai":
+		inner = NewOpenAI(apiKey, model)
+	case "claude", "":
+		inner = NewClaude(apiKey, model)
+	default:
+		return nil, fmt.Errorf("unknown llm provider %q", provider)
+	}
+	return NewAudited(inner), nil
+}

--- a/internal/llm/factory_test.go
+++ b/internal/llm/factory_test.go
@@ -1,0 +1,74 @@
+package llm
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNew_ProviderRouting(t *testing.T) {
+	tests := []struct {
+		name         string
+		provider     string
+		wantInner    any
+		wantErr      bool
+	}{
+		{
+			name:      "openai provider returns AuditedLLM wrapping OpenAIBackend",
+			provider:  "openai",
+			wantInner: &OpenAIBackend{},
+		},
+		{
+			name:      "claude provider returns AuditedLLM wrapping ClaudeBackend",
+			provider:  "claude",
+			wantInner: &ClaudeBackend{},
+		},
+		{
+			name:      "empty provider defaults to claude",
+			provider:  "",
+			wantInner: &ClaudeBackend{},
+		},
+		{
+			name:     "unknown provider returns error",
+			provider: "gemini",
+			wantErr:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := New(tt.provider, "test-key", "test-model")
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.provider)
+				assert.Nil(t, result)
+				return
+			}
+
+			require.NoError(t, err)
+			require.NotNil(t, result)
+
+			// Result must be an AuditedLLM.
+			audited, ok := result.(*AuditedLLM)
+			require.True(t, ok, "expected *AuditedLLM, got %T", result)
+
+			// Inner must be the correct backend type.
+			assert.IsType(t, tt.wantInner, audited.inner)
+		})
+	}
+}
+
+func TestNew_AlwaysWrapsWithAuditLayer(t *testing.T) {
+	llm, err := New("claude", "key", "model")
+	require.NoError(t, err)
+	_, ok := llm.(*AuditedLLM)
+	assert.True(t, ok, "New must always return an *AuditedLLM to ensure audit controls are present")
+}
+
+func TestNew_UnknownProviderErrorMessage(t *testing.T) {
+	_, err := New("unknown-provider", "", "")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unknown llm provider")
+	assert.Contains(t, err.Error(), "unknown-provider")
+}


### PR DESCRIPTION
## Implementation for #-751139312

**Issue:** Fix 2 agent_sec_001 security findings

### Approved Plan
Now I have enough context to produce the plan.

---

### Approach

Introduce an auditing wrapper (`AuditedLLM`) in the `internal/llm` package that implements the `LLM` interface and emits structured `slog` log lines for every `Complete` and `StreamComplete` call (provider, model, token counts, cost, latency, error). Add a factory function `llm.New(provider, apiKey, model string) LLM` that constructs the concrete backend and wraps it in `AuditedLLM`. Update `app.go` to call the factory instead of directly calling `llm.NewOpenAI` / `llm.NewClaude`.

This addresses both findings:
- **openai.go:17** — `NewOpenAI` is called without any audit wrapping; routing through the factory ensures the auditing layer is always present.
- **app.go:178** — the `buildJobHandler` method selects a backend directly; using the factory centralises construction and wrapping.

---

### Files to Modify

| File | Action |
|------|--------|
| `internal/llm/audit.go` | **Create** — `AuditedLLM` wrapper + `NewAudited` constructor |
| `internal/llm/factory.go` | **Create** — `New(provider, apiKey, model string) LLM` factory |
| `internal/app/app.go` | **Modify** — replace direct `llm.NewOpenAI` / `llm.NewClaude` calls with `llm.New(...)` |

---

### Implementation Steps

**1. `internal/llm/audit.go` — auditing wrapper**

```go
package llm

import (
    "context"
    "log/slog"
    "time"
)

// AuditedLLM wraps any LLM and emits structured audit log entries for every call.
type AuditedLLM struct {
    inner LLM
}

// NewAudited wraps inner with audit logging. All callers should obtain LLM
// instances via the llm.New factory rather than constructing backends directly.
func NewAudited(inner LLM) LLM {
    return &AuditedLLM{inner: inner}
}

func (a *AuditedLLM) Name() string { return a.inner.Name() }

func (a *AuditedLLM) Complete(ctx context.Context, req CompletionRequest) (CompletionResponse, error) {
    start := time.Now()
    resp, err := a.inner.Complete(ctx, req)
    attrs := []any{
        "p

### Files Changed
- `internal/app/app.go`
- `internal/llm/audit.go`
- `internal/llm/factory.go`

---
*Created by NeuralWarden Autopilot (event-driven recovery)*