### PR TITLE
feat: implement #-1240253650 — Fix 1 osv_go_2022_0603 security finding

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/openai/openai-go v1.12.0
 	github.com/spf13/cobra v1.10.2
 	github.com/stretchr/testify v1.11.1
-	gopkg.in/yaml.v3 v3.0.1
+	gopkg.in/yaml.v3 v3.0.1 // pinned: v3.0.1 fixes OSV-GO-2022-0603 (YAML bomb DoS)
 	k8s.io/api v0.35.2
 	k8s.io/apimachinery v0.35.2
 	k8s.io/client-go v0.35.2

--- a/go.sum
+++ b/go.sum
@@ -149,7 +149,6 @@ gopkg.in/inf.v0 v0.9.1 h1:73M5CoZyi3ZLMOyDlQh031Cx6N9NDJ2Vvfl76EDAgDc=
 gopkg.in/inf.v0 v0.9.1/go.mod h1:cWUDdTG/fYaXco+Dcufb5Vnc6Gp2YChqWtbxRZE0mXw=
 gopkg.in/yaml.v2 v2.2.8 h1:obN1ZagJSUGI0Ek/LBmuj4SNLPfIny3KsKFopxRdj10=
 gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
-gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 k8s.io/api v0.35.2 h1:tW7mWc2RpxW7HS4CoRXhtYHSzme1PN1UjGHJ1bdrtdw=


### PR DESCRIPTION
## Implementation for #-1240253650

**Issue:** Fix 1 osv_go_2022_0603 security finding

### Approved Plan
Now I have enough information to write the plan.

**Key findings:**
- `go.mod` already directly requires `gopkg.in/yaml.v3 v3.0.1` (the patched version)
- `go.sum` contains `v3.0.0-20200313102051-9f266ea9e77c/go.mod` — this is a go.mod checksum only (not code), present because a transitive dependency in the module graph referenced that old version
- The app uses yaml.v3 directly in `internal/config/repoconfig.go`
- OSV-GO-2022-0603 is an infinite-recursion / YAML bomb DoS, fixed in `v3.0.0` stable; `v3.0.1` is already well past the fix

---

### Approach

The direct dependency (`go.mod`) already pins `gopkg.in/yaml.v3 v3.0.1`, which is the patched version. The scanner is flagging the go.sum entry for the old pseudo-version `v3.0.0-20200313102051-9f266ea9e77c/go.mod` — a checksum record for a transitive dependency's go.mod file, **not** compiled code. The fix is to run `go mod tidy` to prune stale go.sum entries, and if the old entry survives (because a transitive dep still references it), add an explicit `require` to reinforce the minimum version and verify the build is clean.

### Files to Modify

| File | Change |
|------|--------|
| `go.mod` | Confirm (and explicitly keep) `gopkg.in/yaml.v3 v3.0.1`; no version bump needed since v3.0.1 is already patched |
| `go.sum` | Regenerated by `go mod tidy` — the vulnerable pseudo-version's entry should be removed or remain as a go.mod-only hash (not compiled code) |

### Implementation Steps

1. **Verify the current state** — confirm `go.mod` lists `gopkg.in/yaml.v3 v3.0.1` in the `require` block (already confirmed above; no change needed here).

2. **Run `go mod tidy`** to prune any stale/unnecessary entries from `go.sum`:
   ```
   go mod tidy
   ```
   This rebuilds the module graph from scratch and removes entries that are no longer reachable. If `v3.0.0-20200313102051-9f266ea9e77c/go.mod` is not needed to resolve the graph, it will be dropped.

3. **If the entry persists after tidy** (i.e., a transitive dep's go.mod s

### Files Changed
- `go.sum`

---
*Created by NeuralWarden Autopilot (event-driven recovery)*