### PR TITLE
feat: implement #-446488284 — Fix 1 osv_ghsa_hp87_p4gw_j4gq security finding

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -149,7 +149,6 @@ gopkg.in/inf.v0 v0.9.1 h1:73M5CoZyi3ZLMOyDlQh031Cx6N9NDJ2Vvfl76EDAgDc=
 gopkg.in/inf.v0 v0.9.1/go.mod h1:cWUDdTG/fYaXco+Dcufb5Vnc6Gp2YChqWtbxRZE0mXw=
 gopkg.in/yaml.v2 v2.2.8 h1:obN1ZagJSUGI0Ek/LBmuj4SNLPfIny3KsKFopxRdj10=
 gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
-gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 k8s.io/api v0.35.2 h1:tW7mWc2RpxW7HS4CoRXhtYHSzme1PN1UjGHJ1bdrtdw=


### PR DESCRIPTION
## Implementation for #-446488284

**Issue:** Fix 1 osv_ghsa_hp87_p4gw_j4gq security finding

### Approved Plan
Now I have all the information needed. Let me analyze the finding:

- **Vulnerable version**: `gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c` — GHSA-HP87-P4GW-J4GQ (DoS via crafted YAML input)
- **Fixed in**: `v3.0.1`
- **Current `go.mod`**: Already declares `gopkg.in/yaml.v3 v3.0.1` (the patched version)
- **`go.sum` line 152**: `gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:...` — only a `/go.mod` hash (not full source), recorded because a transitive dependency's `go.mod` references that old version

---

### Approach

The direct dependency is already at the patched version (`v3.0.1`). The security scanner is flagging the stale `go.sum` entry for the old version's `go.mod` hash, which Go records for Minimum Version Selection (MVS) graph resolution. Running `go mod tidy` will remove any entries from `go.sum` that are no longer needed; if the old hash is still required by a transitive dependency's `go.mod`, adding an explicit `require` with the patched version (which is already present) ensures MVS always selects `v3.0.1` for actual compilation.

---

### Files to Modify

| File | Action |
|---|---|
| `go.sum` | Regenerated by `go mod tidy` (stale entry removal) |
| `go.mod` | No change required — `v3.0.1` is already declared |

---

### Implementation Steps

1. **Verify current state** — Confirm `go.mod` already pins `gopkg.in/yaml.v3 v3.0.1` (confirmed: line 11).

2. **Run `go mod tidy`** — This re-evaluates the full dependency graph and removes any `go.sum` entries that are no longer reachable. Command:
   ```
   go mod tidy
   ```
   This will regenerate `go.sum` and may remove the stale line:
   ```
   gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
   ```

3. **If the entry persists after tidy** — It means a transitive dependency still lists that old version in its own `go.mod`. In that case, ensure the explicit require is present and add a comment. No `replace` directive is neede

### Files Changed
- `go.sum`

---
*Created by NeuralWarden Autopilot (event-driven recovery)*