### PR TITLE
feat: implement #-1410210621 — Fix 1 osv_go_2022_0603 security finding

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -149,7 +149,6 @@ gopkg.in/inf.v0 v0.9.1 h1:73M5CoZyi3ZLMOyDlQh031Cx6N9NDJ2Vvfl76EDAgDc=
 gopkg.in/inf.v0 v0.9.1/go.mod h1:cWUDdTG/fYaXco+Dcufb5Vnc6Gp2YChqWtbxRZE0mXw=
 gopkg.in/yaml.v2 v2.2.8 h1:obN1ZagJSUGI0Ek/LBmuj4SNLPfIny3KsKFopxRdj10=
 gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
-gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 k8s.io/api v0.35.2 h1:tW7mWc2RpxW7HS4CoRXhtYHSzme1PN1UjGHJ1bdrtdw=


### PR DESCRIPTION
## Implementation for #-1410210621

**Issue:** Fix 1 osv_go_2022_0603 security finding

### Approved Plan
Now I have a clear picture. Let me analyze what's happening:

- `go.mod` line 11: `gopkg.in/yaml.v3 v3.0.1` — **already patched version** (v3.0.1 fixes GO-2022-0603)
- `go.sum` line 152: `gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:...` — a **go.mod-only** reference to the vulnerable version (no source hash `h1:` for the code itself)

The go.sum entry is a module-graph resolution artifact — Go downloaded the old version's `go.mod` to resolve transitive dependencies via MVS (Minimum Version Selection), but the actual compiled code uses v3.0.1. The scanner flags the go.sum entry for the vulnerable version string.

---

### Approach

Run `go mod tidy` to clean up stale `go.sum` entries. The `go.mod` already requires `gopkg.in/yaml.v3 v3.0.1` (the fixed version). The only change needed is removing the lingering go.mod-only reference to the vulnerable pre-release version from `go.sum`.

### Files to Modify

- `go.sum` — remove the stale `gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod` entry via `go mod tidy`

### Implementation Steps

1. **Run `go mod tidy`** in the repository root:
   ```
   go mod tidy
   ```
   This recalculates the minimum required go.sum entries. If `v3.0.0-20200313102051-9f266ea9e77c` is no longer needed for graph resolution (because all transitive dependents now require ≥ v3.0.1 themselves), the entry at `go.sum:152` will be removed automatically.

2. **Verify `go.sum` no longer references the vulnerable version**:
   ```
   grep "yaml.v3 v3.0.0" go.sum
   # Should return nothing
   ```

3. **Verify the build still compiles and tests pass**:
   ```
   make build
   make test
   ```

   No source code changes are required — `go.mod` already pins `gopkg.in/yaml.v3 v3.0.1`.

### Testing

- `grep "yaml.v3 v3.0.0" go.sum` returns no output after tidy.
- `make build` succeeds.
- `make test` passes (all existing tests should be unaffected since no logic changes).
- Re-run the OSV scanner (`osv-scanner --lockfile go.sum`) to 

### Files Changed
- `go.sum`

---
*Created by NeuralWarden Autopilot (event-driven recovery)*