### PR TITLE
feat: implement #-56935177 — Fix 2 agent_sec_001 security findings

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -175,9 +175,9 @@ func (a *App) buildJobHandler() worker.JobHandler {
 	var backend llm.LLM
 	switch a.cfg.LLM.DefaultProvider {
 	case "openai":
-		backend = llm.NewOpenAI(a.cfg.LLM.OpenAI.APIKey, a.cfg.LLM.OpenAI.Model)
+		backend = llm.NewAudited(llm.NewOpenAI(a.cfg.LLM.OpenAI.APIKey, a.cfg.LLM.OpenAI.Model))
 	default:
-		backend = llm.NewClaude(a.cfg.LLM.Claude.APIKey, a.cfg.LLM.Claude.Model)
+		backend = llm.NewAudited(llm.NewClaude(a.cfg.LLM.Claude.APIKey, a.cfg.LLM.Claude.Model))
 	}
 
 	// Create executor based on config.

--- a/internal/llm/audit.go
+++ b/internal/llm/audit.go
@@ -9,6 +9,16 @@ import (
 // AuditedLLM wraps an LLM and emits structured audit log entries for every
 // completion call, satisfying the security requirement that all LLM client
 // usage passes through an auditing layer.
+//
+// Privacy / compliance notes:
+//   - Message content (req.Messages[*].Content, req.System) is NEVER logged to
+//     prevent exposure of PII, PHI, PAN, or other regulated data (GDPR Art. 5,
+//     HIPAA Safe Harbor, PCI-DSS req. 3.3).
+//   - Only structural metadata (message count, boolean flags, token counts,
+//     costs, durations) is emitted; this is the minimum necessary for security
+//     audit and SOX §404 operational-integrity evidence.
+//   - Log consumers are responsible for ensuring log storage meets applicable
+//     retention and tamper-protection requirements (SOX §404, HIPAA §164.312(b)).
 type AuditedLLM struct {
 	inner LLM
 }
@@ -23,6 +33,8 @@ func (a *AuditedLLM) Name() string { return a.inner.Name() }
 
 func (a *AuditedLLM) Complete(ctx context.Context, req CompletionRequest) (CompletionResponse, error) {
 	start := time.Now()
+	// NOTE: req.Messages content and req.System are intentionally omitted to
+	// prevent PII/PHI/PAN from appearing in audit logs.
 	slog.Info("llm.Complete started",
 		"provider", a.inner.Name(),
 		"model", req.Model,
@@ -32,6 +44,7 @@ func (a *AuditedLLM) Complete(ctx context.Context, req CompletionRequest) (Compl
 
 	resp, err := a.inner.Complete(ctx, req)
 
+	// NOTE: resp.Content is intentionally omitted for the same PII reasons.
 	attrs := []any{
 		"provider", a.inner.Name(),
 		"model", resp.Model,
@@ -48,14 +61,46 @@ func (a *AuditedLLM) Complete(ctx context.Context, req CompletionRequest) (Compl
 	return resp, err
 }
 
+// StreamComplete wraps the inner stream and emits a completion audit entry
+// (with duration) when the stream finishes or errors, providing a full audit
+// trail for SOX §404 purposes. Token counts and costs are not available from
+// individual StreamChunks; use Complete for calls where those metrics are
+// required.
 func (a *AuditedLLM) StreamComplete(ctx context.Context, req CompletionRequest) (<-chan StreamChunk, error) {
+	start := time.Now()
+	// NOTE: req.Model is the only request field logged; content is omitted.
 	slog.Info("llm.StreamComplete started",
 		"provider", a.inner.Name(),
 		"model", req.Model,
 	)
-	ch, err := a.inner.StreamComplete(ctx, req)
+	innerCh, err := a.inner.StreamComplete(ctx, req)
 	if err != nil {
-		slog.Error("llm.StreamComplete failed", "provider", a.inner.Name(), "error", err)
+		slog.Error("llm.StreamComplete failed",
+			"provider", a.inner.Name(),
+			"duration_ms", time.Since(start).Milliseconds(),
+			"error", err,
+		)
+		return nil, err
 	}
-	return ch, err
+
+	out := make(chan StreamChunk)
+	go func() {
+		defer close(out)
+		for chunk := range innerCh {
+			out <- chunk
+			if chunk.Done || chunk.Error != nil {
+				attrs := []any{
+					"provider", a.inner.Name(),
+					"duration_ms", time.Since(start).Milliseconds(),
+				}
+				if chunk.Error != nil {
+					slog.Error("llm.StreamComplete finished with error", append(attrs, "error", chunk.Error)...)
+				} else {
+					slog.Info("llm.StreamComplete finished", attrs...)
+				}
+				return
+			}
+		}
+	}()
+	return out, nil
 }

--- a/internal/llm/audit.go
+++ b/internal/llm/audit.go
@@ -1,0 +1,61 @@
+package llm
+
+import (
+	"context"
+	"log/slog"
+	"time"
+)
+
+// AuditedLLM wraps an LLM and emits structured audit log entries for every
+// completion call, satisfying the security requirement that all LLM client
+// usage passes through an auditing layer.
+type AuditedLLM struct {
+	inner LLM
+}
+
+// NewAudited returns an LLM that wraps inner with audit logging.
+// All callers must use this factory instead of instantiating backends directly.
+func NewAudited(inner LLM) LLM {
+	return &AuditedLLM{inner: inner}
+}
+
+func (a *AuditedLLM) Name() string { return a.inner.Name() }
+
+func (a *AuditedLLM) Complete(ctx context.Context, req CompletionRequest) (CompletionResponse, error) {
+	start := time.Now()
+	slog.Info("llm.Complete started",
+		"provider", a.inner.Name(),
+		"model", req.Model,
+		"message_count", len(req.Messages),
+		"has_system", req.System != "",
+	)
+
+	resp, err := a.inner.Complete(ctx, req)
+
+	attrs := []any{
+		"provider", a.inner.Name(),
+		"model", resp.Model,
+		"input_tokens", resp.InputTokens,
+		"output_tokens", resp.OutputTokens,
+		"cost_usd", resp.Cost,
+		"duration_ms", time.Since(start).Milliseconds(),
+	}
+	if err != nil {
+		slog.Error("llm.Complete failed", append(attrs, "error", err)...)
+	} else {
+		slog.Info("llm.Complete finished", attrs...)
+	}
+	return resp, err
+}
+
+func (a *AuditedLLM) StreamComplete(ctx context.Context, req CompletionRequest) (<-chan StreamChunk, error) {
+	slog.Info("llm.StreamComplete started",
+		"provider", a.inner.Name(),
+		"model", req.Model,
+	)
+	ch, err := a.inner.StreamComplete(ctx, req)
+	if err != nil {
+		slog.Error("llm.StreamComplete failed", "provider", a.inner.Name(), "error", err)
+	}
+	return ch, err
+}

--- a/internal/llm/audit_test.go
+++ b/internal/llm/audit_test.go
@@ -3,6 +3,8 @@ package llm
 import (
 	"context"
 	"errors"
+	"log/slog"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -10,10 +12,11 @@ import (
 )
 
 type stubLLM struct {
-	name     string
-	resp     CompletionResponse
-	err      error
-	called   bool
+	name        string
+	resp        CompletionResponse
+	err         error
+	called      bool
+	streamChunks []StreamChunk
 }
 
 func (s *stubLLM) Name() string { return s.name }
@@ -24,7 +27,44 @@ func (s *stubLLM) Complete(_ context.Context, _ CompletionRequest) (CompletionRe
 }
 
 func (s *stubLLM) StreamComplete(_ context.Context, _ CompletionRequest) (<-chan StreamChunk, error) {
-	return nil, s.err
+	if s.err != nil {
+		return nil, s.err
+	}
+	ch := make(chan StreamChunk, len(s.streamChunks))
+	for _, c := range s.streamChunks {
+		ch <- c
+	}
+	close(ch)
+	return ch, nil
+}
+
+// captureHandler is a minimal slog.Handler that records all log attributes
+// as "key=value" strings so tests can assert on what was (not) logged.
+type captureHandler struct {
+	records []string
+}
+
+func (h *captureHandler) Enabled(_ context.Context, _ slog.Level) bool { return true }
+func (h *captureHandler) WithAttrs(attrs []slog.Attr) slog.Handler      { return h }
+func (h *captureHandler) WithGroup(name string) slog.Handler            { return h }
+
+func (h *captureHandler) Handle(_ context.Context, r slog.Record) error {
+	r.Attrs(func(a slog.Attr) bool {
+		h.records = append(h.records, a.Key+"="+a.Value.String())
+		return true
+	})
+	// Also capture the message itself.
+	h.records = append(h.records, "msg="+r.Message)
+	return nil
+}
+
+func (h *captureHandler) contains(s string) bool {
+	for _, rec := range h.records {
+		if strings.Contains(rec, s) {
+			return true
+		}
+	}
+	return false
 }
 
 func TestAuditedLLM_Complete_delegates(t *testing.T) {
@@ -69,4 +109,84 @@ func TestAuditedLLM_StreamComplete_propagates_error(t *testing.T) {
 
 	assert.Nil(t, ch)
 	assert.ErrorIs(t, err, stubErr)
+}
+
+func TestAuditedLLM_StreamComplete_relays_chunks(t *testing.T) {
+	chunks := []StreamChunk{
+		{Content: "hello"},
+		{Content: " world", Done: true},
+	}
+	stub := &stubLLM{name: "stub", streamChunks: chunks}
+	audited := NewAudited(stub)
+
+	ch, err := audited.StreamComplete(context.Background(), CompletionRequest{Model: "gpt-4"})
+
+	require.NoError(t, err)
+	require.NotNil(t, ch)
+
+	var got []StreamChunk
+	for c := range ch {
+		got = append(got, c)
+	}
+	assert.Equal(t, chunks, got)
+}
+
+// TestAuditedLLM_Complete_noPIILogged verifies that message content, system
+// prompt text, and response content are never written to the audit log,
+// preventing accidental exposure of PII, PHI, or PAN.
+func TestAuditedLLM_Complete_noPIILogged(t *testing.T) {
+	h := &captureHandler{}
+	orig := slog.Default()
+	slog.SetDefault(slog.New(h))
+	defer slog.SetDefault(orig)
+
+	sensitiveContent := "SSN: 123-45-6789 card: 4111111111111111"
+	stub := &stubLLM{
+		name: "stub",
+		resp: CompletionResponse{
+			Content:      sensitiveContent,
+			Model:        "gpt-4",
+			InputTokens:  5,
+			OutputTokens: 10,
+		},
+	}
+	audited := NewAudited(stub)
+
+	req := CompletionRequest{
+		System:   sensitiveContent,
+		Messages: []Message{{Role: RoleUser, Content: sensitiveContent}},
+		Model:    "gpt-4",
+	}
+	_, err := audited.Complete(context.Background(), req)
+	require.NoError(t, err)
+
+	assert.False(t, h.contains(sensitiveContent),
+		"audit log must not contain PII/PHI/PAN content; got records: %v", h.records)
+}
+
+// TestAuditedLLM_StreamComplete_noPIILogged verifies that streamed content is
+// not written to the audit log.
+func TestAuditedLLM_StreamComplete_noPIILogged(t *testing.T) {
+	h := &captureHandler{}
+	orig := slog.Default()
+	slog.SetDefault(slog.New(h))
+	defer slog.SetDefault(orig)
+
+	sensitiveContent := "secret PII data"
+	stub := &stubLLM{
+		name: "stub",
+		streamChunks: []StreamChunk{
+			{Content: sensitiveContent},
+			{Content: " more", Done: true},
+		},
+	}
+	audited := NewAudited(stub)
+
+	ch, err := audited.StreamComplete(context.Background(), CompletionRequest{Model: "gpt-4"})
+	require.NoError(t, err)
+	for range ch {
+	}
+
+	assert.False(t, h.contains(sensitiveContent),
+		"audit log must not contain streamed content; got records: %v", h.records)
 }

--- a/internal/llm/audit_test.go
+++ b/internal/llm/audit_test.go
@@ -1,0 +1,72 @@
+package llm
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type stubLLM struct {
+	name     string
+	resp     CompletionResponse
+	err      error
+	called   bool
+}
+
+func (s *stubLLM) Name() string { return s.name }
+
+func (s *stubLLM) Complete(_ context.Context, _ CompletionRequest) (CompletionResponse, error) {
+	s.called = true
+	return s.resp, s.err
+}
+
+func (s *stubLLM) StreamComplete(_ context.Context, _ CompletionRequest) (<-chan StreamChunk, error) {
+	return nil, s.err
+}
+
+func TestAuditedLLM_Complete_delegates(t *testing.T) {
+	want := CompletionResponse{
+		Content:      "hello",
+		Model:        "gpt-4",
+		InputTokens:  10,
+		OutputTokens: 5,
+		Cost:         0.001,
+	}
+	stub := &stubLLM{name: "stub", resp: want}
+	audited := NewAudited(stub)
+
+	got, err := audited.Complete(context.Background(), CompletionRequest{Model: "gpt-4"})
+
+	require.NoError(t, err)
+	assert.Equal(t, want, got)
+	assert.True(t, stub.called)
+}
+
+func TestAuditedLLM_Complete_propagates_error(t *testing.T) {
+	stubErr := errors.New("backend error")
+	stub := &stubLLM{name: "stub", err: stubErr}
+	audited := NewAudited(stub)
+
+	_, err := audited.Complete(context.Background(), CompletionRequest{})
+
+	assert.ErrorIs(t, err, stubErr)
+}
+
+func TestAuditedLLM_Name(t *testing.T) {
+	stub := &stubLLM{name: "myprovider"}
+	assert.Equal(t, "myprovider", NewAudited(stub).Name())
+}
+
+func TestAuditedLLM_StreamComplete_propagates_error(t *testing.T) {
+	stubErr := errors.New("stream error")
+	stub := &stubLLM{name: "stub", err: stubErr}
+	audited := NewAudited(stub)
+
+	ch, err := audited.StreamComplete(context.Background(), CompletionRequest{})
+
+	assert.Nil(t, ch)
+	assert.ErrorIs(t, err, stubErr)
+}


### PR DESCRIPTION
## Implementation for #-56935177

**Issue:** Fix 2 agent_sec_001 security findings

### Approved Plan
I have enough context. Here is the implementation plan:

---

### Approach

Introduce an `AuditedLLM` wrapper in `internal/llm/audit.go` that implements the `LLM` interface and emits structured `slog` audit log entries before and after every `Complete` / `StreamComplete` call. Then update `internal/app/app.go` to wrap each backend through the new `NewAudited` factory rather than using the backends directly. This is a minimal, focused change that resolves both scanner findings without altering business logic.

---

### Files to Modify

| File | Action |
|---|---|
| `internal/llm/audit.go` | **Create** — `AuditedLLM` wrapper + `NewAudited` factory |
| `internal/app/app.go` | **Modify** — wrap backends via `llm.NewAudited(...)` at lines 178-181 |

---

### Implementation Steps

**Step 1 — Create `internal/llm/audit.go`**

```go
package llm

import (
    "context"
    "log/slog"
    "time"
)

// AuditedLLM wraps an LLM and emits structured audit log entries for every
// completion call, satisfying the security requirement that all LLM client
// usage passes through an auditing layer.
type AuditedLLM struct {
    inner LLM
}

// NewAudited returns an LLM that wraps inner with audit logging.
// All callers must use this factory instead of instantiating backends directly.
func NewAudited(inner LLM) LLM {
    return &AuditedLLM{inner: inner}
}

func (a *AuditedLLM) Name() string { return a.inner.Name() }

func (a *AuditedLLM) Complete(ctx context.Context, req CompletionRequest) (CompletionResponse, error) {
    start := time.Now()
    slog.Info("llm.Complete started",
        "provider", a.inner.Name(),
        "model", req.Model,
        "message_count", len(req.Messages),
        "has_system", req.System != "",
    )

    resp, err := a.inner.Complete(ctx, req)

    attrs := []any{
        "provider", a.inner.Name(),
        "model", resp.Model,
        "input_tokens", resp.InputTokens,
        "output_tokens", resp.OutputTokens,
        "cost_usd", resp.Cost,
        "du

### Files Changed
- `internal/app/app.go`
- `internal/llm/audit.go`
- `internal/llm/audit_test.go`

---
*Created by NeuralWarden Autopilot (event-driven recovery)*