### PR TITLE
feat: implement #-566790135 — Fix 1 osv_ghsa_hp87_p4gw_j4gq security finding

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/openai/openai-go v1.12.0
 	github.com/spf13/cobra v1.10.2
 	github.com/stretchr/testify v1.11.1
-	gopkg.in/yaml.v3 v3.0.1
+	gopkg.in/yaml.v3 v3.0.1 // pin: fix GHSA-hp87-p4gw-j4gq
 	k8s.io/api v0.35.2
 	k8s.io/apimachinery v0.35.2
 	k8s.io/client-go v0.35.2

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/openai/openai-go v1.12.0
 	github.com/spf13/cobra v1.10.2
 	github.com/stretchr/testify v1.11.1
-	gopkg.in/yaml.v3 v3.0.1
+	gopkg.in/yaml.v3 v3.0.1 // pin: fix GHSA-hp87-p4gw-j4gq (DoS in pre-release yaml.v3)
 	k8s.io/api v0.35.2
 	k8s.io/apimachinery v0.35.2
 	k8s.io/client-go v0.35.2

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/openai/openai-go v1.12.0
 	github.com/spf13/cobra v1.10.2
 	github.com/stretchr/testify v1.11.1
-	gopkg.in/yaml.v3 v3.0.1 // pin: fix GHSA-hp87-p4gw-j4gq
+	gopkg.in/yaml.v3 v3.0.1
 	k8s.io/api v0.35.2
 	k8s.io/apimachinery v0.35.2
 	k8s.io/client-go v0.35.2

--- a/go.sum
+++ b/go.sum
@@ -149,7 +149,6 @@ gopkg.in/inf.v0 v0.9.1 h1:73M5CoZyi3ZLMOyDlQh031Cx6N9NDJ2Vvfl76EDAgDc=
 gopkg.in/inf.v0 v0.9.1/go.mod h1:cWUDdTG/fYaXco+Dcufb5Vnc6Gp2YChqWtbxRZE0mXw=
 gopkg.in/yaml.v2 v2.2.8 h1:obN1ZagJSUGI0Ek/LBmuj4SNLPfIny3KsKFopxRdj10=
 gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
-gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 k8s.io/api v0.35.2 h1:tW7mWc2RpxW7HS4CoRXhtYHSzme1PN1UjGHJ1bdrtdw=


### PR DESCRIPTION
## Implementation for #-566790135

**Issue:** Fix 1 osv_ghsa_hp87_p4gw_j4gq security finding

### Approved Plan
Now I have enough context to write the plan.

### Approach

GHSA-hp87-p4gw-j4gq is a denial-of-service vulnerability in `gopkg.in/yaml.v3` affecting the pre-release version `3.0.0-20200313102051-9f266ea9e77c`. The direct dependency in `go.mod` is already at the safe version `v3.0.1`. However, `go.sum` still contains a `/go.mod`-only hash entry for the vulnerable pre-release — it was fetched solely to resolve the module dependency graph, so the vulnerable source code is **not** compiled into the binary. The scanner flags the stale reference in `go.sum`.

The fix is to run `go mod tidy` to remove the stale entry. If the entry persists (because a transitive dep's own `go.mod` still lists the old version), an explicit minimum-version pin already exists in `go.mod` at `v3.0.1`, so no further action is needed beyond confirming the binary is safe.

---

### Files to Modify

| File | Change |
|------|--------|
| `go.sum` | Remove stale `gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod` entry via `go mod tidy` |
| `go.mod` | Already correct (`gopkg.in/yaml.v3 v3.0.1`); no change required |

---

### Implementation Steps

1. **Confirm current state** — `go.mod` already declares `gopkg.in/yaml.v3 v3.0.1` as a direct dependency (line 11). This is the patched version.

2. **Run `go mod tidy`** — This prunes unreachable entries from `go.sum`. If no remaining transitive dependency references `v3.0.0-20200313102051-9f266ea9e77c` in its own `go.mod`, the stale line will be removed:
   ```
   gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
   ```

3. **Verify the entry is gone** — After `go mod tidy`, confirm `go.sum` no longer contains a line matching `gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c`.

4. **If the entry persists** (a transitive dep still transitively requires the old version in its `go.mod`): the Go toolchain's Minimum Version Selection (MVS) guarantees the resolved version is `v3.0.1`. In that

### Files Changed
- `go.mod`
- `go.sum`

---
*Created by NeuralWarden Autopilot (event-driven recovery)*