### PR TITLE
feat: implement #-1295965290 — Fix 2 agent_sec_001 security findings

### DIFF
--- a/internal/llm/audit.go
+++ b/internal/llm/audit.go
@@ -1,0 +1,41 @@
+package llm
+
+import (
+	"context"
+	"log/slog"
+	"time"
+)
+
+// AuditingLLM wraps an LLM backend and emits a structured audit log entry
+// for every completion call, recording provider, model, token usage, cost,
+// latency, and any error.
+type AuditingLLM struct {
+	inner LLM
+}
+
+// NewAudited wraps inner with audit logging. Every Complete call will emit
+// a slog entry at Info level with key "llm_audit".
+func NewAudited(inner LLM) LLM {
+	return &AuditingLLM{inner: inner}
+}
+
+func (a *AuditingLLM) Name() string { return a.inner.Name() }
+
+func (a *AuditingLLM) Complete(ctx context.Context, req CompletionRequest) (CompletionResponse, error) {
+	start := time.Now()
+	resp, err := a.inner.Complete(ctx, req)
+	slog.InfoContext(ctx, "llm_audit",
+		"provider", a.inner.Name(),
+		"model", req.Model,
+		"input_tokens", resp.InputTokens,
+		"output_tokens", resp.OutputTokens,
+		"cost_usd", resp.Cost,
+		"latency_ms", time.Since(start).Milliseconds(),
+		"error", err,
+	)
+	return resp, err
+}
+
+func (a *AuditingLLM) StreamComplete(ctx context.Context, req CompletionRequest) (<-chan StreamChunk, error) {
+	return a.inner.StreamComplete(ctx, req)
+}

--- a/internal/llm/audit_test.go
+++ b/internal/llm/audit_test.go
@@ -1,0 +1,89 @@
+package llm
+
+import (
+	"context"
+	"log/slog"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// mockLLM is a simple LLM implementation for testing.
+type mockLLM struct {
+	name string
+	resp CompletionResponse
+	err  error
+}
+
+func (m *mockLLM) Name() string { return m.name }
+
+func (m *mockLLM) Complete(_ context.Context, _ CompletionRequest) (CompletionResponse, error) {
+	return m.resp, m.err
+}
+
+func (m *mockLLM) StreamComplete(_ context.Context, _ CompletionRequest) (<-chan StreamChunk, error) {
+	return nil, nil
+}
+
+// testSlogHandler captures slog records for assertion.
+type testSlogHandler struct {
+	records []slog.Record
+}
+
+func (h *testSlogHandler) Enabled(_ context.Context, _ slog.Level) bool { return true }
+
+func (h *testSlogHandler) Handle(_ context.Context, r slog.Record) error {
+	h.records = append(h.records, r)
+	return nil
+}
+
+func (h *testSlogHandler) WithAttrs(attrs []slog.Attr) slog.Handler { return h }
+func (h *testSlogHandler) WithGroup(name string) slog.Handler       { return h }
+
+func TestAuditingLLM_Complete(t *testing.T) {
+	mock := &mockLLM{
+		name: "test-provider",
+		resp: CompletionResponse{
+			Content:      "hello",
+			Model:        "test-model",
+			InputTokens:  10,
+			OutputTokens: 5,
+			Cost:         0.001,
+		},
+	}
+
+	handler := &testSlogHandler{}
+	orig := slog.Default()
+	slog.SetDefault(slog.New(handler))
+	t.Cleanup(func() { slog.SetDefault(orig) })
+
+	audited := NewAudited(mock)
+	require.Equal(t, "test-provider", audited.Name())
+
+	resp, err := audited.Complete(context.Background(), CompletionRequest{Model: "test-model"})
+	require.NoError(t, err)
+	assert.Equal(t, mock.resp, resp)
+
+	require.Len(t, handler.records, 1)
+	rec := handler.records[0]
+	assert.Equal(t, "llm_audit", rec.Message)
+
+	attrs := map[string]any{}
+	rec.Attrs(func(a slog.Attr) bool {
+		attrs[a.Key] = a.Value.Any()
+		return true
+	})
+	assert.Equal(t, "test-provider", attrs["provider"])
+	assert.Equal(t, "test-model", attrs["model"])
+	assert.Equal(t, int64(10), attrs["input_tokens"])
+	assert.Equal(t, int64(5), attrs["output_tokens"])
+}
+
+func TestAuditingLLM_StreamComplete(t *testing.T) {
+	mock := &mockLLM{name: "test-provider"}
+	audited := NewAudited(mock)
+	ch, err := audited.StreamComplete(context.Background(), CompletionRequest{})
+	assert.Nil(t, ch)
+	assert.NoError(t, err)
+}

--- a/internal/llm/claude.go
+++ b/internal/llm/claude.go
@@ -14,12 +14,9 @@ type ClaudeBackend struct {
 	model  string
 }
 
-func NewClaude(apiKey, model string) *ClaudeBackend {
+func NewClaude(apiKey, model string) LLM {
 	client := anthropic.NewClient(option.WithAPIKey(apiKey))
-	return &ClaudeBackend{
-		client: client,
-		model:  model,
-	}
+	return NewAudited(&ClaudeBackend{client: client, model: model})
 }
 
 func (c *ClaudeBackend) Name() string {

--- a/internal/llm/openai.go
+++ b/internal/llm/openai.go
@@ -14,12 +14,9 @@ type OpenAIBackend struct {
 	model  string
 }
 
-func NewOpenAI(apiKey, model string) *OpenAIBackend {
+func NewOpenAI(apiKey, model string) LLM {
 	client := openai.NewClient(option.WithAPIKey(apiKey))
-	return &OpenAIBackend{
-		client: client,
-		model:  model,
-	}
+	return NewAudited(&OpenAIBackend{client: client, model: model})
 }
 
 func (o *OpenAIBackend) Name() string {


### PR DESCRIPTION
## Implementation for #-1295965290

**Issue:** Fix 2 agent_sec_001 security findings

### Approved Plan
Now I have enough context to produce the implementation plan.

---

### Approach

Introduce an `AuditingLLM` decorator in the `llm` package that wraps any `LLM` backend and emits a structured `slog` audit log entry on every call. Update `NewOpenAI` (and `NewClaude` for consistency) to return the interface type `LLM` and wrap the concrete backend in the auditing decorator before returning. This ensures every LLM client is always created through an auditing path — fixing both findings without changing `app.go`.

---

### Files to Modify

| File | Action |
|---|---|
| `internal/llm/audit.go` | **Create** — `AuditingLLM` struct + `NewAudited(LLM) LLM` |
| `internal/llm/openai.go` | **Modify** — `NewOpenAI` returns `LLM` and wraps backend with `NewAudited` |
| `internal/llm/claude.go` | **Modify** — `NewClaude` returns `LLM` and wraps backend with `NewAudited` |

`internal/app/app.go` does **not** need changes; once both factory functions return audited wrappers, calls at lines 178–180 are automatically covered.

---

### Implementation Steps

**Step 1 — Create `internal/llm/audit.go`**

```go
package llm

import (
    "context"
    "log/slog"
    "time"
)

// AuditingLLM wraps an LLM backend and emits a structured audit log entry
// for every completion call, recording provider, model, token usage, cost,
// latency, and any error.
type AuditingLLM struct {
    inner LLM
}

// NewAudited wraps inner with audit logging. Every Complete call will emit
// a slog entry at Info level with key "llm_audit".
func NewAudited(inner LLM) LLM {
    return &AuditingLLM{inner: inner}
}

func (a *AuditingLLM) Name() string { return a.inner.Name() }

func (a *AuditingLLM) Complete(ctx context.Context, req CompletionRequest) (CompletionResponse, error) {
    start := time.Now()
    resp, err := a.inner.Complete(ctx, req)
    slog.InfoContext(ctx, "llm_audit",
        "provider", a.inner.Name(),
        "model", req.Model,
        "input_tokens", resp.InputTokens,
        "output_tokens", 

### Files Changed
- `internal/llm/audit.go`
- `internal/llm/audit_test.go`
- `internal/llm/claude.go`
- `internal/llm/openai.go`

---
*Created by NeuralWarden Autopilot (event-driven recovery)*