### PR TITLE
feat: implement #-44956971 — Fix 1 osv_ghsa_hp87_p4gw_j4gq security finding

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -149,7 +149,6 @@ gopkg.in/inf.v0 v0.9.1 h1:73M5CoZyi3ZLMOyDlQh031Cx6N9NDJ2Vvfl76EDAgDc=
 gopkg.in/inf.v0 v0.9.1/go.mod h1:cWUDdTG/fYaXco+Dcufb5Vnc6Gp2YChqWtbxRZE0mXw=
 gopkg.in/yaml.v2 v2.2.8 h1:obN1ZagJSUGI0Ek/LBmuj4SNLPfIny3KsKFopxRdj10=
 gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
-gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 k8s.io/api v0.35.2 h1:tW7mWc2RpxW7HS4CoRXhtYHSzme1PN1UjGHJ1bdrtdw=

--- a/internal/deps/deps_security_test.go
+++ b/internal/deps/deps_security_test.go
@@ -1,0 +1,61 @@
+package deps_test
+
+import (
+	"bufio"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// knownVulnerableVersions maps package names to versions with known security
+// advisories. Each entry should reference the relevant advisory ID.
+var knownVulnerableVersions = []struct {
+	pkg      string
+	version  string
+	advisory string
+}{
+	{
+		pkg:      "gopkg.in/yaml.v3",
+		version:  "v3.0.0-20200313102051-9f266ea9e77c",
+		advisory: "GHSA-hp87-p4gw-j4gq",
+	},
+}
+
+// TestGoSumNoVulnerableVersions verifies that go.sum does not contain entries
+// for dependency versions with known security advisories. This catches
+// regressions where a vulnerable version is reintroduced via transitive
+// dependency changes.
+func TestGoSumNoVulnerableVersions(t *testing.T) {
+	f, err := os.Open("../../go.sum")
+	require.NoError(t, err, "failed to open go.sum")
+	defer f.Close()
+
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		line := scanner.Text()
+		for _, vuln := range knownVulnerableVersions {
+			marker := vuln.pkg + " " + vuln.version
+			assert.False(t, strings.Contains(line, marker),
+				"go.sum contains vulnerable dependency %s %s (advisory: %s)",
+				vuln.pkg, vuln.version, vuln.advisory,
+			)
+		}
+	}
+	require.NoError(t, scanner.Err(), "error reading go.sum")
+}
+
+// TestGoModPinnedVersions verifies that go.mod pins dependencies at or above
+// their minimum safe versions for packages with known advisories.
+func TestGoModPinnedVersions(t *testing.T) {
+	data, err := os.ReadFile("../../go.mod")
+	require.NoError(t, err, "failed to read go.mod")
+
+	content := string(data)
+
+	// Verify yaml.v3 is required at v3.0.1 or later (patched for GHSA-hp87-p4gw-j4gq)
+	assert.Contains(t, content, "gopkg.in/yaml.v3 v3.0.1",
+		"go.mod should pin gopkg.in/yaml.v3 to v3.0.1 or later (GHSA-hp87-p4gw-j4gq)")
+}


### PR DESCRIPTION
## Implementation for #-44956971

**Issue:** Fix 1 osv_ghsa_hp87_p4gw_j4gq security finding

### Approved Plan
Now I have enough context. Let me analyze what the scanner is finding and what's needed.

**Key observations:**
- `go.mod` already requires `gopkg.in/yaml.v3 v3.0.1` (the patched version) as a direct dependency
- `go.sum` line 152 contains: `gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:...` — this is only a `/go.mod` hash (no `h1:` source hash), meaning the vulnerable version's source code was never compiled in; it exists solely for MVS (minimum version selection) module graph resolution
- The scanner flags the go.sum entry because the vulnerable version string appears there

The actual binary uses v3.0.1 (patched), but the go.sum retains the old version's `go.mod` fingerprint from a transitive dependency's requirements. Running `go mod tidy` should regenerate go.sum and remove the stale entry if it's no longer needed for module graph resolution.

---

### Approach

Run `go mod tidy` to regenerate go.sum. The direct dependency in go.mod is already at v3.0.1 (patched). The vulnerable version only appears in go.sum as a `/go.mod` hash from a transitive dependency's minimum requirement — `go mod tidy` will remove it if it is no longer needed for graph resolution.

### Files to Modify

- `go.sum` — stale entry for `gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod` needs to be removed (via `go mod tidy`, not manual edit)

### Implementation Steps

1. **Run `go mod tidy`** in the repo root:
   ```
   go mod tidy
   ```
   This re-computes the full module graph and rewrites go.sum, removing any hash entries that are no longer needed. Since go.mod already pins `gopkg.in/yaml.v3 v3.0.1`, the old pre-release go.mod hash should be dropped.

2. **Verify the entry is gone** from go.sum:
   ```
   grep "yaml.v3 v3.0.0-20200313102051" go.sum
   ```
   Expected: no output.

3. **If the entry persists** after `go mod tidy` (some transitive dep still requires the old version as its minimum), add an explicit `require` override in go.mod (it is already presen

### Files Changed
- `go.sum`

---
*Created by NeuralWarden Autopilot (event-driven recovery)*