### PR TITLE
feat: implement #-1686351800 — Fix 2 agent_sec_001 security findings

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -175,9 +175,9 @@ func (a *App) buildJobHandler() worker.JobHandler {
 	var backend llm.LLM
 	switch a.cfg.LLM.DefaultProvider {
 	case "openai":
-		backend = llm.NewOpenAI(a.cfg.LLM.OpenAI.APIKey, a.cfg.LLM.OpenAI.Model)
+		backend = llm.NewAuditedOpenAI(a.cfg.LLM.OpenAI.APIKey, a.cfg.LLM.OpenAI.Model)
 	default:
-		backend = llm.NewClaude(a.cfg.LLM.Claude.APIKey, a.cfg.LLM.Claude.Model)
+		backend = llm.NewAuditedClaude(a.cfg.LLM.Claude.APIKey, a.cfg.LLM.Claude.Model)
 	}
 
 	// Create executor based on config.

--- a/internal/llm/audited.go
+++ b/internal/llm/audited.go
@@ -1,0 +1,59 @@
+package llm
+
+import (
+	"context"
+	"log/slog"
+	"time"
+)
+
+// AuditedBackend wraps an LLM and logs every call with provider, model, tokens, cost, and duration.
+type AuditedBackend struct {
+	inner LLM
+}
+
+// NewAudited wraps any LLM backend with audit logging.
+func NewAudited(inner LLM) *AuditedBackend {
+	return &AuditedBackend{inner: inner}
+}
+
+// NewAuditedOpenAI creates an OpenAI backend wrapped with audit logging.
+func NewAuditedOpenAI(apiKey, model string) *AuditedBackend {
+	return NewAudited(NewOpenAI(apiKey, model))
+}
+
+// NewAuditedClaude creates a Claude backend wrapped with audit logging.
+func NewAuditedClaude(apiKey, model string) *AuditedBackend {
+	return NewAudited(NewClaude(apiKey, model))
+}
+
+func (a *AuditedBackend) Name() string {
+	return a.inner.Name()
+}
+
+func (a *AuditedBackend) Complete(ctx context.Context, req CompletionRequest) (CompletionResponse, error) {
+	start := time.Now()
+	slog.Info("llm call started", "provider", a.inner.Name(), "model", req.Model)
+
+	resp, err := a.inner.Complete(ctx, req)
+	duration := time.Since(start)
+
+	if err != nil {
+		slog.Error("llm call failed", "provider", a.inner.Name(), "duration", duration, "error", err)
+		return resp, err
+	}
+
+	slog.Info("llm call completed",
+		"provider", a.inner.Name(),
+		"model", resp.Model,
+		"input_tokens", resp.InputTokens,
+		"output_tokens", resp.OutputTokens,
+		"cost", resp.Cost,
+		"duration", duration,
+	)
+	return resp, nil
+}
+
+func (a *AuditedBackend) StreamComplete(ctx context.Context, req CompletionRequest) (<-chan StreamChunk, error) {
+	slog.Info("llm stream started", "provider", a.inner.Name(), "model", req.Model)
+	return a.inner.StreamComplete(ctx, req)
+}

--- a/internal/llm/audited_test.go
+++ b/internal/llm/audited_test.go
@@ -1,0 +1,92 @@
+package llm
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type mockLLM struct {
+	name     string
+	resp     CompletionResponse
+	err      error
+	called   bool
+	lastReq  CompletionRequest
+}
+
+func (m *mockLLM) Name() string { return m.name }
+
+func (m *mockLLM) Complete(_ context.Context, req CompletionRequest) (CompletionResponse, error) {
+	m.called = true
+	m.lastReq = req
+	return m.resp, m.err
+}
+
+func (m *mockLLM) StreamComplete(_ context.Context, _ CompletionRequest) (<-chan StreamChunk, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+
+func TestAuditedBackend(t *testing.T) {
+	tests := []struct {
+		name      string
+		mockName  string
+		mockResp  CompletionResponse
+		mockErr   error
+		req       CompletionRequest
+		wantErr   bool
+	}{
+		{
+			name:     "delegates to inner backend and returns response",
+			mockName: "openai",
+			mockResp: CompletionResponse{
+				Content:      "hello",
+				Model:        "gpt-4",
+				InputTokens:  10,
+				OutputTokens: 5,
+				Cost:         0.001,
+			},
+			req: CompletionRequest{
+				Model:    "gpt-4",
+				Messages: []Message{{Role: RoleUser, Content: "hi"}},
+			},
+			wantErr: false,
+		},
+		{
+			name:     "propagates errors from inner backend",
+			mockName: "claude",
+			mockErr:  fmt.Errorf("api error"),
+			req: CompletionRequest{
+				Model: "claude-3",
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mock := &mockLLM{
+				name: tt.mockName,
+				resp: tt.mockResp,
+				err:  tt.mockErr,
+			}
+
+			audited := NewAudited(mock)
+
+			assert.Equal(t, tt.mockName, audited.Name())
+
+			resp, err := audited.Complete(context.Background(), tt.req)
+
+			assert.True(t, mock.called, "inner backend should be called")
+			assert.Equal(t, tt.req, mock.lastReq, "request should be passed through unchanged")
+
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.mockResp, resp, "response should be passed through unchanged")
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Implementation for #-1686351800

Closes #-1686351800

**Issue:** Fix 2 agent_sec_001 security findings

### Approved Plan
Now I have a clear picture. Here's the implementation plan:

---

### Approach

Create an auditing LLM wrapper that implements the `llm.LLM` interface, logs all LLM calls (provider, model, token usage, cost, duration), and delegates to the underlying backend. Introduce a factory function `llm.NewAudited(backend LLM) LLM` that wraps any backend with this logging. Update `app.go` to use factory functions (`llm.NewAuditedOpenAI`, `llm.NewAuditedClaude`) instead of calling `NewOpenAI`/`NewClaude` directly. The `NewOpenAI` and `NewClaude` constructors remain available but the app-level code routes through the auditing wrapper.

### Files to Modify

1. **`internal/llm/audited.go`** (new) — Auditing wrapper + factory functions
2. **`internal/llm/audited_test.go`** (new) — Tests for the wrapper
3. **`internal/app/app.go`** — Switch to audited factory functions

### Implementation Steps

**Step 1: Create `internal/llm/audited.go`**

```go
package llm

import (
	"context"
	"log/slog"
	"time"
)

// AuditedBackend wraps an LLM and logs every call with provider, model, tokens, cost, and duration.
type AuditedBackend struct {
	inner LLM
}

// NewAudited wraps any LLM backend with audit logging.
func NewAudited(inner LLM) *AuditedBackend {
	return &AuditedBackend{inner: inner}
}

// NewAuditedOpenAI creates an OpenAI backend wrapped with audit logging.
func NewAuditedOpenAI(apiKey, model string) *AuditedBackend {
	return NewAudited(NewOpenAI(apiKey, model))
}

// NewAuditedClaude creates a Claude backend wrapped with audit logging.
func NewAuditedClaude(apiKey, model string) *AuditedBackend {
	return NewAudited(NewClaude(apiKey, model))
}

func (a *AuditedBackend) Name() string {
	return a.inner.Name()
}

func (a *AuditedBackend) Complete(ctx context.Context, req CompletionRequest) (CompletionResponse, error) {
	start := time.Now()
	slog.Info("llm call started", "provider", a.inner.Name(), "model", req.Model)

	resp, err := a.inner.Complete(ctx, req)
	duration := time.Since(start)

### Files Changed
- `internal/app/app.go`
- `internal/llm/audited.go`
- `internal/llm/audited_test.go`

---
*Created by NeuralWarden Autopilot (event-driven recovery)*