### PR TITLE
feat: implement #-1557868525 — Fix 1 osv_go_2022_0603 security finding

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/openai/openai-go v1.12.0
 	github.com/spf13/cobra v1.10.2
 	github.com/stretchr/testify v1.11.1
-	gopkg.in/yaml.v3 v3.0.1
+	gopkg.in/yaml.v3 v3.0.1 // security: >= v3.0.1 required (OSV-GO-2022-0603)
 	k8s.io/api v0.35.2
 	k8s.io/apimachinery v0.35.2
 	k8s.io/client-go v0.35.2

--- a/go.sum
+++ b/go.sum
@@ -149,7 +149,6 @@ gopkg.in/inf.v0 v0.9.1 h1:73M5CoZyi3ZLMOyDlQh031Cx6N9NDJ2Vvfl76EDAgDc=
 gopkg.in/inf.v0 v0.9.1/go.mod h1:cWUDdTG/fYaXco+Dcufb5Vnc6Gp2YChqWtbxRZE0mXw=
 gopkg.in/yaml.v2 v2.2.8 h1:obN1ZagJSUGI0Ek/LBmuj4SNLPfIny3KsKFopxRdj10=
 gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
-gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 k8s.io/api v0.35.2 h1:tW7mWc2RpxW7HS4CoRXhtYHSzme1PN1UjGHJ1bdrtdw=


### PR DESCRIPTION
## Implementation for #-1557868525

Closes #-1557868525

**Issue:** Fix 1 osv_go_2022_0603 security finding

### Approved Plan
### Approach

The vulnerability **OSV-GO-2022-0603** (CVSS 5.0) affects `gopkg.in/yaml.v3` versions before `v3.0.1` — it's a denial-of-service via crafted YAML input. 

The **go.mod** already pins `gopkg.in/yaml.v3 v3.0.1` (the fixed version) as a direct dependency. However, **go.sum** still contains a checksum entry for the vulnerable version `v3.0.0-20200313102051-9f266ea9e77c` (line 152), which is what the scanner flags. This stale entry exists because a transitive dependency's `go.mod` once referenced that older version. Running `go mod tidy` will clean up go.sum by removing entries no longer needed by the current module graph.

### Files to Modify

1. **go.sum** — Remove stale checksum entry for `gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c`

### Implementation Steps

1. Run `go mod tidy` to prune stale entries from `go.sum`. This will remove the `gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod` line if it's no longer needed by any transitive dependency.

2. If `go mod tidy` does **not** remove the entry (because a transitive dependency's `go.mod` still references it), then:
   - Run `go mod graph | grep yaml.v3` to identify which dependency pulls in the old version.
   - The old `/go.mod`-only entry in go.sum is informational (Go needs it to verify the module graph), but the actual resolved version is `v3.0.1`. In this case, the finding is a false positive from the scanner — the binary is not vulnerable. Document this in the PR description.

3. Verify the direct dependency remains at `v3.0.1` in `go.mod` (already the case — no change needed).

4. Run `make build && make test` to confirm nothing breaks.

### Testing

- `make build` — confirms the project compiles with the updated go.sum
- `make test` — confirms all tests pass
- Re-run the security scanner (or manually verify `go.sum` no longer contains the vulnerable version string) to confirm the finding is resolved

### Risks

- **Low risk**: `go mod tidy` may also clean up other stale entri

### Files Changed
- `go.sum`

---
*Created by NeuralWarden Autopilot (event-driven recovery)*