### PR TITLE
feat: implement #15 — MEDIUM: Job claim race condition in worker pool

### DIFF
--- a/internal/store/sqlite.go
+++ b/internal/store/sqlite.go
@@ -205,6 +205,33 @@ func (s *SQLiteStore) ListPendingJobs(ctx context.Context, limit int) ([]Job, er
 	return jobs, rows.Err()
 }
 
+func (s *SQLiteStore) ClaimPendingJobs(ctx context.Context, limit int) ([]Job, error) {
+	ctx, cancel := context.WithTimeout(ctx, DefaultDBTimeout)
+	defer cancel()
+	rows, err := s.db.QueryContext(ctx,
+		`UPDATE jobs SET status = ?, updated_at = ?
+		 WHERE id IN (
+		     SELECT id FROM jobs WHERE status = ? ORDER BY created_at ASC LIMIT ?
+		 )
+		 RETURNING id, repo_full_name, issue_number, issue_title, status, current_stage,
+		           pipeline_state, error, cost_usd, created_at, updated_at, completed_at`,
+		JobRunning, time.Now().UTC(), JobQueued, limit,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("claim pending jobs: %w", err)
+	}
+	defer rows.Close()
+	var jobs []Job
+	for rows.Next() {
+		j, err := s.scanJob(rows)
+		if err != nil {
+			return nil, fmt.Errorf("scan claimed job: %w", err)
+		}
+		jobs = append(jobs, *j)
+	}
+	return jobs, rows.Err()
+}
+
 func (s *SQLiteStore) UpsertRepoContext(ctx context.Context, rc RepoContextRecord) error {
 	ctx, cancel := context.WithTimeout(ctx, DefaultDBTimeout)
 	defer cancel()

--- a/internal/store/sqlite_test.go
+++ b/internal/store/sqlite_test.go
@@ -72,6 +72,21 @@ func TestCompleteJob(t *testing.T) {
 	assert.NotNil(t, got.CompletedAt)
 }
 
+func TestClaimPendingJobs(t *testing.T) {
+	s := newTestStore(t)
+	require.NoError(t, s.CreateJob(context.Background(), Job{ID: "j1", RepoFullName: "o/r", IssueNumber: 1, Status: JobQueued}))
+
+	claimed, err := s.ClaimPendingJobs(context.Background(), 5)
+	require.NoError(t, err)
+	assert.Len(t, claimed, 1)
+	assert.Equal(t, JobRunning, claimed[0].Status)
+
+	// Second call should find nothing queued
+	claimed2, err := s.ClaimPendingJobs(context.Background(), 5)
+	require.NoError(t, err)
+	assert.Len(t, claimed2, 0)
+}
+
 func TestContextCancellation(t *testing.T) {
 	s := newTestStore(t)
 	ctx, cancel := context.WithCancel(context.Background())

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -46,6 +46,7 @@ type Store interface {
 	UpdateJobCost(ctx context.Context, id string, cost float64) error
 	CompleteJob(ctx context.Context, id string, status JobStatus) error
 	ListPendingJobs(ctx context.Context, limit int) ([]Job, error)
+	ClaimPendingJobs(ctx context.Context, limit int) ([]Job, error)
 	UpsertRepoContext(ctx context.Context, rc RepoContextRecord) error
 	GetRepoContext(ctx context.Context, repoFullName string) (*RepoContextRecord, error)
 	Migrate(ctx context.Context) error

--- a/internal/worker/pool.go
+++ b/internal/worker/pool.go
@@ -59,16 +59,12 @@ func (p *Pool) poll(ctx context.Context) {
 		case <-ctx.Done():
 			return
 		case <-ticker.C:
-			jobs, err := p.store.ListPendingJobs(ctx, p.size)
+			jobs, err := p.store.ClaimPendingJobs(ctx, p.size)
 			if err != nil {
 				slog.Error("poll error", "error", err)
 				continue
 			}
 			for _, job := range jobs {
-				if err := p.store.UpdateJobStatus(ctx, job.ID, store.JobRunning, ""); err != nil {
-					slog.Error("update job status", "error", err)
-					continue
-				}
 				select {
 				case p.jobs <- job:
 				case <-ctx.Done():

--- a/internal/worker/pool_test.go
+++ b/internal/worker/pool_test.go
@@ -13,22 +13,16 @@ import (
 
 type mockStore struct {
 	store.Store
-	jobs    []store.Job
-	updated int32
+	jobs []store.Job
 }
 
-func (m *mockStore) ListPendingJobs(ctx context.Context, limit int) ([]store.Job, error) {
+func (m *mockStore) ClaimPendingJobs(ctx context.Context, limit int) ([]store.Job, error) {
 	if len(m.jobs) == 0 {
 		return nil, nil
 	}
 	j := m.jobs[0]
 	m.jobs = m.jobs[1:]
 	return []store.Job{j}, nil
-}
-
-func (m *mockStore) UpdateJobStatus(ctx context.Context, id string, status store.JobStatus, stage string) error {
-	atomic.AddInt32(&m.updated, 1)
-	return nil
 }
 
 func (m *mockStore) CompleteJob(ctx context.Context, id string, status store.JobStatus) error {


### PR DESCRIPTION
## Implementation for #15

Closes #15

**Issue:** MEDIUM: Job claim race condition in worker pool

### Approved Plan
Now I have all the context needed. Here's the implementation plan:

---

### Approach

Replace the two-step `ListPendingJobs` + `UpdateJobStatus` sequence in `pool.poll` with a single atomic `ClaimPendingJobs` operation. SQLite's WAL mode allows only one writer at a time, so an `UPDATE ... WHERE id IN (SELECT ...) RETURNING *` statement is inherently atomic — no second poller can claim the same job between the SELECT and UPDATE.

### Files to Modify

1. `internal/store/store.go` — add `ClaimPendingJobs` to the `Store` interface
2. `internal/store/sqlite.go` — implement `ClaimPendingJobs` with an atomic UPDATE...RETURNING
3. `internal/worker/pool.go` — replace `ListPendingJobs`+`UpdateJobStatus` loop with `ClaimPendingJobs`
4. `internal/worker/pool_test.go` — add `ClaimPendingJobs` to `mockStore`, remove now-unused `ListPendingJobs`+`UpdateJobStatus` mocks
5. `internal/store/sqlite_test.go` — add test for `ClaimPendingJobs`

### Implementation Steps

**Step 1 — `internal/store/store.go`**: Add new method to `Store` interface after `ListPendingJobs`:
```go
ClaimPendingJobs(ctx context.Context, limit int) ([]Job, error)
```

**Step 2 — `internal/store/sqlite.go`**: Implement `ClaimPendingJobs` using a single atomic SQL statement. SQLite 3.35+ supports `RETURNING`:
```go
func (s *SQLiteStore) ClaimPendingJobs(ctx context.Context, limit int) ([]Job, error) {
    ctx, cancel := context.WithTimeout(ctx, DefaultDBTimeout)
    defer cancel()
    rows, err := s.db.QueryContext(ctx,
        `UPDATE jobs SET status = ?, updated_at = ?
         WHERE id IN (
             SELECT id FROM jobs WHERE status = ? ORDER BY created_at ASC LIMIT ?
         )
         RETURNING id, repo_full_name, issue_number, issue_title, status, current_stage,
                   pipeline_state, error, cost_usd, created_at, updated_at, completed_at`,
        JobRunning, time.Now().UTC(), JobQueued, limit,
    )
    if err != nil {
        return nil, fmt.Errorf("claim pending jobs: %w", err)
    }
    d

### Files Changed
- `internal/store/sqlite.go`
- `internal/store/sqlite_test.go`
- `internal/store/store.go`
- `internal/worker/pool.go`
- `internal/worker/pool_test.go`

---
*Created by NeuralWarden Autopilot (event-driven recovery)*